### PR TITLE
Adjust device authentication flow

### DIFF
--- a/visitz/Visitz/Services/DeviceAuthenticator.cs
+++ b/visitz/Visitz/Services/DeviceAuthenticator.cs
@@ -11,22 +11,15 @@ namespace Visitz.Services
     {
         public async Task<Result> Authenticate()
         {
-            if (await CrossFingerprint.Current.IsAvailableAsync())
+            var request = new AuthenticationRequestConfiguration(LocalizedStrings.DeviceAuthTitle,
+                LocalizedStrings.DeviceAuthReason)
             {
-                var request = new AuthenticationRequestConfiguration(LocalizedStrings.DeviceAuthTitle,
-                    LocalizedStrings.DeviceAuthReason)
-                {
-                    AllowAlternativeAuthentication = true,
-                };
+                AllowAlternativeAuthentication = true,
+            };
 
-                var result = await CrossFingerprint.Current.AuthenticateAsync(request);
+            var result = await CrossFingerprint.Current.AuthenticateAsync(request);
 
-                return result.Authenticated ? Result.Successful : Result.Failure;
-            }
-            else
-            {
-                return Result.NotConfigured;
-            }
+            return result.Authenticated ? Result.Successful : Result.Failure;
         }
 
         public enum Result


### PR DESCRIPTION
The library function doesn't check if a passcode has been set. So if the user has set up a passcode (without biometrics) they'll be treated as if they have no security set up, which is false.

This is a TODO to fix in the future, but for now, it's acceptable to remove this check since device policies force the user to implement some kind of passcode.