### PR TITLE
Network check

### DIFF
--- a/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
+++ b/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
@@ -2,8 +2,8 @@
 {
     public class VisitzSession
     {
-        private static AuthenticationClient AuthClient => Application.Current.Handler.MauiContext
-                .Services.GetRequiredService<AuthenticationClient>();
+        private static AuthenticationClient AuthClient => 
+            ServiceProvider.Current.GetRequiredService<AuthenticationClient>();
 
         private static bool InternetAvailable => 
             Connectivity.Current.NetworkAccess == NetworkAccess.Internet;

--- a/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
+++ b/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
@@ -5,8 +5,14 @@
         private static AuthenticationClient AuthClient => Application.Current.Handler.MauiContext
                 .Services.GetRequiredService<AuthenticationClient>();
 
+        private static bool InternetAvailable => 
+            Connectivity.Current.NetworkAccess == NetworkAccess.Internet;
+
         public static async Task<bool> GetValidSessionAsync()
         {
+            if (!InternetAvailable)
+                return false;
+
             return await TokenHolder.IsAccessTokenValid()
                 || await TryRefreshAsync()
                 || await LoginAsync();


### PR DESCRIPTION
Implement a network check in VisitzSession when ensuring access to a valid session.

This is a limited implementation—all it does is early-return `false` if the device has no internet connectivity. It won't publish messages or inform UI updates. Those features will need to be implemented in a separate, more focused work item.