### PR TITLE
Prevent publishing notes when offline

### DIFF
--- a/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
+++ b/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
@@ -10,7 +10,7 @@ namespace Visitz.Authentication.Keycloak
 
         public static event EventHandler<SessionChangedEventArgs> SessionChanged;
 
-        public static async Task<bool> GetValidSessionAsync()
+        public static async Task<bool> TryGetValidSessionAsync()
         {
             if (!NetworkHelper.InternetAvailable)
                 return false;

--- a/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
+++ b/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
@@ -1,4 +1,5 @@
 ﻿using Visitz.Authentication.Keycloak.Events;
+using Visitz.Network;
 
 namespace Visitz.Authentication.Keycloak
 {
@@ -7,14 +8,11 @@ namespace Visitz.Authentication.Keycloak
         private static AuthenticationClient AuthClient =>
             ServiceProvider.Current.GetRequiredService<AuthenticationClient>();
 
-        private static bool InternetAvailable =>
-            Connectivity.Current.NetworkAccess == NetworkAccess.Internet;
-
         public static event EventHandler<SessionChangedEventArgs> SessionChanged;
 
         public static async Task<bool> GetValidSessionAsync()
         {
-            if (!InternetAvailable)
+            if (!NetworkHelper.InternetAvailable)
                 return false;
 
             return await TokenHolder.IsAccessTokenValid()

--- a/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
+++ b/visitz/Visitz/Authentication/Keycloak/VisitzSession.cs
@@ -1,4 +1,6 @@
-﻿using Visitz.Authentication.Keycloak.Events;
+﻿using IdentityModel.OidcClient;
+using IdentityModel.OidcClient.Results;
+using Visitz.Authentication.Keycloak.Events;
 using Visitz.Network;
 
 namespace Visitz.Authentication.Keycloak
@@ -10,61 +12,76 @@ namespace Visitz.Authentication.Keycloak
 
         public static event EventHandler<SessionChangedEventArgs> SessionChanged;
 
-        public static async Task<bool> TryGetValidSessionAsync()
+        public static async Task AssertValidSessionAsync()
         {
-            if (!NetworkHelper.InternetAvailable)
-                return false;
+            NetworkHelper.AssertInternetAvailable();
 
-            return await TokenHolder.IsAccessTokenValid()
-                || await TryRefreshAsync()
-                || await LoginAsync();
+            if (!await TokenHolder.IsAccessTokenValid())
+            {
+                if (await TokenHolder.IsRefreshTokenExpired())
+                    await LoginAsync();
+                else
+                    await RefreshAsync();
+            }
         }
 
-        public static async Task<bool> LoginAsync()
+        public static async Task LoginAsync()
         {
-            var loginResult = await AuthClient.LoginAsync();
-            var loginSuccess = !loginResult.IsError;
+            LoginResult loginResult = null;
 
-            if (loginSuccess)
+            try
+            {
+                NetworkHelper.AssertInternetAvailable();
+
+                loginResult = await AuthClient.LoginAsync();
+
+                if (loginResult.IsError)
+                    throw new LoginException(loginResult.Error);
+
                 await TokenHolder.SaveAsync(loginResult);
-
+            }
+            finally
+            {
 #if DEBUG
-            ConsoleTrace.TraceMethod(typeof(VisitzSession),
-                $"loginResult.IsError: '{loginResult.IsError}', error: '{loginResult.Error}'");
+                ConsoleTrace.TraceMethod(typeof(VisitzSession),
+                    $"loginResult.IsError: '{loginResult?.IsError}', error: '{loginResult?.Error}'");
 #endif
-
-            var info = await VisitzSessionInfo.GetAsync();
-            SessionChanged?.Invoke(info, new LoginChangedEventArgs() { Success = loginSuccess });
-
-            return loginSuccess;
+                var info = await VisitzSessionInfo.GetAsync();
+                SessionChanged?.Invoke(info, new LoginChangedEventArgs()
+                { 
+                    Success = !loginResult?.IsError ?? false 
+                });
+            }
         }
 
-        private static async Task<bool> TryRefreshAsync()
+        private static async Task RefreshAsync()
         {
-            if (await TokenHolder.IsRefreshTokenExpired())
-                return false;
+            RefreshTokenResult refreshResult = null;
 
-            return await RefreshAsync();
-        }
+            try
+            {
+                NetworkHelper.AssertInternetAvailable();
 
-        private static async Task<bool> RefreshAsync()
-        {
-            var refreshToken = await TokenHolder.GetRefreshTokenStringAsync();
-            var refreshResult = await AuthClient.RefreshAsync(refreshToken);
-            var refreshSuccess = !refreshResult.IsError;
+                var refreshToken = await TokenHolder.GetRefreshTokenStringAsync();
+                refreshResult = await AuthClient.RefreshAsync(refreshToken);
 
-            if (refreshSuccess)
+                if (refreshResult.IsError)
+                    throw new SessionRefreshException(refreshResult.Error);
+
                 await TokenHolder.SaveAsync(refreshResult);
-
+            }
+            finally
+            {
 #if DEBUG
-            ConsoleTrace.TraceMethod(typeof(VisitzSession), 
-                $"refreshResult.IsError: '{refreshResult.IsError}', error: '{refreshResult.Error}'");
+                ConsoleTrace.TraceMethod(typeof(VisitzSession), 
+                    $"refreshResult.IsError: '{refreshResult?.IsError}', error: '{refreshResult?.Error}'");
 #endif
-
-            var info = await VisitzSessionInfo.GetAsync();
-            SessionChanged?.Invoke(info, new RefreshChangedEventArgs() { Success = refreshSuccess });
-
-            return refreshSuccess;
+                var info = await VisitzSessionInfo.GetAsync();
+                SessionChanged?.Invoke(info, new RefreshChangedEventArgs() 
+                { 
+                    Success = !refreshResult?.IsError ?? false 
+                });
+            }
         }
 
         public static async Task<bool> LogoutAsync()
@@ -76,7 +93,6 @@ namespace Visitz.Authentication.Keycloak
             ConsoleTrace.TraceMethod(typeof(VisitzSession),
                 $"logoutResult.IsError: '{logoutResult.IsError}', error: '{logoutResult.Error}'");
 #endif
-
             await InvalidateSessionAsync();
 
             var info = await VisitzSessionInfo.GetAsync();

--- a/visitz/Visitz/Authentication/Keycloak/WebBrowserAuthenticator.cs
+++ b/visitz/Visitz/Authentication/Keycloak/WebBrowserAuthenticator.cs
@@ -56,6 +56,14 @@ namespace Visitz.Authentication.Keycloak
                     ErrorDescription = LocalizedStrings.UserCancelledAuth
                 };
             }
+            catch (Exception ex)
+            {
+                return new BrowserResult
+                {
+                    ResultType = BrowserResultType.UnknownError,
+                    ErrorDescription = ex.Message
+                };
+            }
         }
 
         /*

--- a/visitz/Visitz/Authentication/LoginException.cs
+++ b/visitz/Visitz/Authentication/LoginException.cs
@@ -1,0 +1,9 @@
+﻿namespace Visitz.Authentication;
+
+public class LoginException : Exception
+{
+    public LoginException(string message) : base(message)
+    {
+
+    }
+}

--- a/visitz/Visitz/Authentication/SessionRefreshException.cs
+++ b/visitz/Visitz/Authentication/SessionRefreshException.cs
@@ -1,0 +1,9 @@
+﻿namespace Visitz.Authentication;
+
+public class SessionRefreshException : Exception
+{
+    public SessionRefreshException(string message) : base(message)
+    {
+
+    }
+}

--- a/visitz/Visitz/Behaviors/DisableWhenInternetUnavailableBehavior.cs
+++ b/visitz/Visitz/Behaviors/DisableWhenInternetUnavailableBehavior.cs
@@ -1,0 +1,38 @@
+﻿namespace Visitz.Behaviors;
+
+public class DisableWhenInternetUnavailableBehavior : Behavior<View>
+{
+    private View View { get; set; }
+
+    protected override void OnAttachedTo(View bindable)
+    {
+        base.OnAttachedTo(bindable);
+        View = bindable;
+
+        bindable.BindingContextChanged += Bindable_BindingContextChanged;
+        Connectivity.Current.ConnectivityChanged += Current_ConnectivityChanged;
+    }
+
+    protected override void OnDetachingFrom(View bindable)
+    {
+        Connectivity.Current.ConnectivityChanged -= Current_ConnectivityChanged;
+        bindable.BindingContextChanged -= Bindable_BindingContextChanged;
+
+        base.OnDetachingFrom(bindable);
+    }
+
+    private void Bindable_BindingContextChanged(object sender, EventArgs e)
+    {
+        ApplyNetworkStyles(Connectivity.Current.NetworkAccess);
+    }
+
+    private void Current_ConnectivityChanged(object sender, ConnectivityChangedEventArgs e)
+    {
+        ApplyNetworkStyles(e.NetworkAccess);
+    }
+
+    private void ApplyNetworkStyles(NetworkAccess networkAccess)
+    {
+        View.IsEnabled = networkAccess == NetworkAccess.Internet;
+    }
+}

--- a/visitz/Visitz/Extensions/ParentChangingEventArgsExtension.cs
+++ b/visitz/Visitz/Extensions/ParentChangingEventArgsExtension.cs
@@ -1,0 +1,14 @@
+﻿namespace Visitz.Extensions;
+
+public static class ParentChangingEventArgsExtension
+{
+    public static bool AttachingToParent(this ParentChangingEventArgs e)
+    {
+        return e.OldParent == null && e.NewParent != null;
+    }
+
+    public static bool DetachingFromParent(this ParentChangingEventArgs e)
+    {
+        return e.OldParent != null && e.NewParent == null;
+    }
+}

--- a/visitz/Visitz/Network/InternetUnavailableException.cs
+++ b/visitz/Visitz/Network/InternetUnavailableException.cs
@@ -1,0 +1,9 @@
+﻿namespace Visitz.Network;
+
+public class InternetUnavailableException : Exception
+{
+    public InternetUnavailableException(string message) : base(message)
+    {
+
+    }
+}

--- a/visitz/Visitz/Network/NetworkHelper.cs
+++ b/visitz/Visitz/Network/NetworkHelper.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Visitz.Network;
+
+public static class NetworkHelper
+{
+    public static bool InternetAvailable => Connectivity.Current.NetworkAccess == NetworkAccess.Internet;
+}

--- a/visitz/Visitz/Network/NetworkHelper.cs
+++ b/visitz/Visitz/Network/NetworkHelper.cs
@@ -1,6 +1,16 @@
-﻿namespace Visitz.Network;
+﻿using Visitz.Resources.Localization;
+
+namespace Visitz.Network;
 
 public static class NetworkHelper
 {
     public static bool InternetAvailable => Connectivity.Current.NetworkAccess == NetworkAccess.Internet;
+
+    public static void AssertInternetAvailable(string messageIfUnavailable = null)
+    {
+        messageIfUnavailable ??= LocalizedStrings.NoInternet;
+
+        if (!InternetAvailable)
+            throw new InternetUnavailableException(messageIfUnavailable);
+    }
 }

--- a/visitz/Visitz/Network/NetworkHelper.cs
+++ b/visitz/Visitz/Network/NetworkHelper.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-namespace Visitz.Network;
+﻿namespace Visitz.Network;
 
 public static class NetworkHelper
 {

--- a/visitz/Visitz/Pages/NoteEntryPage.xaml
+++ b/visitz/Visitz/Pages/NoteEntryPage.xaml
@@ -3,9 +3,11 @@
     xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:toolkit="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+    xmlns:behaviors="clr-namespace:Visitz.Behaviors"
     xmlns:pages="clr-namespace:Visitz.Pages"
     xmlns:subclasses="clr-namespace:Visitz.Subclasses"
     xmlns:viewModels="clr-namespace:Visitz.ViewModels"
+    xmlns:views="clr-namespace:Visitz.Views"
     xmlns:fonticons="clr-namespace:Visitz.FontIcons"
     x:Class="Visitz.Pages.NoteEntryPage"
     x:DataType="viewModels:NoteEntryViewModel"
@@ -45,11 +47,21 @@
             Style="{StaticResource transparent}"
             IsVisible="false" />
 
-        <Button
+        <HorizontalStackLayout 
             Grid.Row="0"
             Grid.Column="2"
-            Text="Publish"
-            Command="{Binding PublishNotesCommand}" />
+            Spacing="10">
+
+            <views:InternetInfoView />
+
+            <Button
+                Text="Publish"
+                Command="{Binding PublishNotesCommand}">
+                <Button.Behaviors>
+                    <behaviors:DisableWhenInternetUnavailableBehavior />
+                </Button.Behaviors>
+            </Button>
+        </HorizontalStackLayout>
 
         <Label
             x:Name="PromptLabel"

--- a/visitz/Visitz/Pages/VisitzPage.xaml.cs
+++ b/visitz/Visitz/Pages/VisitzPage.xaml.cs
@@ -57,7 +57,7 @@ public abstract partial class VisitzPage : ContentPage
     protected override void OnParentChanging(ParentChangingEventArgs args)
     {
         base.OnParentChanging(args);
-
+        // TODO: Implement ParentChangingEventArgsExtension here
         var isCreating = args.OldParent == null && args.NewParent != null;
         var isDestroying = args.OldParent != null && args.NewParent == null;
 

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -236,7 +236,7 @@ namespace Visitz.Resources.Localization {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Internet connection unavailable.
+        ///   Looks up a localized string similar to No internet available.
         /// </summary>
         internal static string NoInternet {
             get {

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -124,6 +124,15 @@ namespace Visitz.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Connected—no internet available.
+        /// </summary>
+        internal static string ConnectedNoInternet {
+            get {
+                return ResourceManager.GetString("ConnectedNoInternet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to MCFD Mobility contains Private Information and may only be accessed by authorized users..
         /// </summary>
         internal static string DeviceAuthReason {

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -227,6 +227,15 @@ namespace Visitz.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Internet connection unavailable.
+        /// </summary>
+        internal static string NoInternet {
+            get {
+                return ResourceManager.GetString("NoInternet", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to There are no notes for this {0}.
         /// </summary>
         internal static string NoNotesForEntity {

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -420,6 +420,15 @@ namespace Visitz.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to You aren&apos;t authorized to use this feature..
+        /// </summary>
+        internal static string UnauthorizedForApi {
+            get {
+                return ResourceManager.GetString("UnauthorizedForApi", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to User cancelled IDIR login..
         /// </summary>
         internal static string UserCancelledAuth {

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -246,7 +246,7 @@ However, you currently aren't authorized to use MCFD Mobility. Please request ac
     <value>Character limit reached</value>
   </data>
   <data name="NoInternet" xml:space="preserve">
-    <value>Internet connection unavailable</value>
+    <value>No internet available</value>
   </data>
   <data name="UnauthorizedForApi" xml:space="preserve">
     <value>You aren't authorized to use this feature.</value>

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -245,4 +245,7 @@ However, you currently aren't authorized to use MCFD Mobility. Please request ac
   <data name="CharacterLimitReached" xml:space="preserve">
     <value>Character limit reached</value>
   </data>
+  <data name="NoInternet" xml:space="preserve">
+    <value>Internet connection unavailable</value>
+  </data>
 </root>

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -248,4 +248,7 @@ However, you currently aren't authorized to use MCFD Mobility. Please request ac
   <data name="NoInternet" xml:space="preserve">
     <value>Internet connection unavailable</value>
   </data>
+  <data name="UnauthorizedForApi" xml:space="preserve">
+    <value>You aren't authorized to use this feature.</value>
+  </data>
 </root>

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -251,4 +251,7 @@ However, you currently aren't authorized to use MCFD Mobility. Please request ac
   <data name="UnauthorizedForApi" xml:space="preserve">
     <value>You aren't authorized to use this feature.</value>
   </data>
+  <data name="ConnectedNoInternet" xml:space="preserve">
+    <value>Connected—no internet available</value>
+  </data>
 </root>

--- a/visitz/Visitz/Resources/Styles/Colors.xaml
+++ b/visitz/Visitz/Resources/Styles/Colors.xaml
@@ -6,8 +6,10 @@
 
     <!-- https://developer.gov.bc.ca/Colour-Palette -->
     <Color x:Key="BC_Blue">#003366</Color>
+    <Color x:Key="BC_Blue_Disabled">#CDDADF</Color>
     <Color x:Key="BC_Gold">#FCBA19</Color>
     <Color x:Key="BC_TextColor">#313132</Color>
+    <Color x:Key="BC_TextColor_Disabled">#424242</Color>
     <Color x:Key="BC_Hyperlink">#1A5A96</Color>
     <Color x:Key="BC_Background_Dark">#38598A</Color>
     <Color x:Key="BC_Background_Light">#F2F2F2</Color>

--- a/visitz/Visitz/Resources/Styles/Styles.xaml
+++ b/visitz/Visitz/Resources/Styles/Styles.xaml
@@ -38,8 +38,8 @@
                     <VisualState x:Name="Normal" />
                     <VisualState x:Name="Disabled">
                         <VisualState.Setters>
-                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource Gray950}, Dark={StaticResource Gray950}}" />
-                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray200}}" />
+                            <Setter Property="TextColor" Value="{AppThemeBinding Light={StaticResource BC_TextColor_Disabled}, Dark={StaticResource BC_TextColor_Disabled}}" />
+                            <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource BC_Blue_Disabled}, Dark={StaticResource BC_Blue_Disabled}}" />
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>

--- a/visitz/Visitz/Services/GetAllDataForOfflineService.cs
+++ b/visitz/Visitz/Services/GetAllDataForOfflineService.cs
@@ -35,7 +35,7 @@ namespace Visitz.Services
             return MakeId();
         }
 
-        protected override async Task RunAsync()
+        protected override async Task RunApiServiceAsync()
         {
             await Task.Run(async () =>
             {

--- a/visitz/Visitz/Services/GetCaseloadService.cs
+++ b/visitz/Visitz/Services/GetCaseloadService.cs
@@ -26,7 +26,7 @@ namespace Visitz.Services
 
         public GetCaseloadService(Vpi vpi) : base(vpi) { }
 
-        protected override async Task RunAsync()
+        protected override async Task RunApiServiceAsync()
         {
             await GetCaseloadAsync();
         }

--- a/visitz/Visitz/Services/GetNotesForRangeService.cs
+++ b/visitz/Visitz/Services/GetNotesForRangeService.cs
@@ -35,7 +35,7 @@ namespace Visitz.Services
             return MakeId();
         }
 
-        protected override async Task RunAsync()
+        protected override async Task RunApiServiceAsync()
         {
             await GetAllNotesAsync();
         }

--- a/visitz/Visitz/Services/GetNotesService.cs
+++ b/visitz/Visitz/Services/GetNotesService.cs
@@ -37,7 +37,7 @@ namespace Visitz.Services
             return MakeId(caseIncidentId);
         }
 
-        protected override async Task RunAsync()
+        protected override async Task RunApiServiceAsync()
         {
             await GetNotesAsync();
         }

--- a/visitz/Visitz/Services/ServiceHandler.cs
+++ b/visitz/Visitz/Services/ServiceHandler.cs
@@ -55,7 +55,7 @@ namespace Visitz.Services
         {
             try
             {
-                await service.OnRunAsync();
+                await service.RunAsync();
             }
             catch (Exception ex)
             {
@@ -66,7 +66,7 @@ namespace Visitz.Services
             }
             finally
             {
-                await service.OnFinishAsync();
+                await service.FinishAsync();
             }
         }
 

--- a/visitz/Visitz/Services/ServiceHandler.cs
+++ b/visitz/Visitz/Services/ServiceHandler.cs
@@ -32,7 +32,7 @@ namespace Visitz.Services
         /// </summary>
         /// <param name="startMessage"></param>
         /// <returns></returns>
-        public async Task TryRunServiceAsync(StartServiceMessage startMessage)
+        public async Task<VisitzService.Result> TryRunServiceAsync(StartServiceMessage startMessage)
         {
             // Only allow 1 service per ID at a time. For now, ServiceHandler shouldn't need to worry about
             // queueing services or distributing workloads.
@@ -43,12 +43,15 @@ namespace Visitz.Services
                 try
                 {
                     await RunServiceAsync(service);
+                    return service.ResultCode;
                 }
                 finally
                 {
                     Services.Remove(startMessage.ServiceId);
                 }
             }
+            else
+                return VisitzService.Result.NoOperation;
         }
 
         private async Task RunServiceAsync(VisitzService service)

--- a/visitz/Visitz/Services/SubmitAndGetNotesService.cs
+++ b/visitz/Visitz/Services/SubmitAndGetNotesService.cs
@@ -45,7 +45,6 @@ namespace Visitz.Services
 
         private async Task SubmitNote(SubmitNoteEntity noteEntity)
         {
-            var info = await VisitzSessionInfo.GetAsync();
             await ServiceHandler.TryRunServiceAsync(SubmitNoteService.MakeStartMessage(noteEntity));
         }
 

--- a/visitz/Visitz/Services/SubmitAndGetNotesService.cs
+++ b/visitz/Visitz/Services/SubmitAndGetNotesService.cs
@@ -36,7 +36,7 @@ namespace Visitz.Services
             return MakeId(Payload.EntityNumber, Payload.NotePeriod);
         }
 
-        protected override async Task RunAsync()
+        protected override async Task RunApiServiceAsync()
         {
             await SubmitNote(Payload);
             await GetNotes(Payload.EntityNumber, Payload.EntityType);

--- a/visitz/Visitz/Services/SubmitAndGetNotesService.cs
+++ b/visitz/Visitz/Services/SubmitAndGetNotesService.cs
@@ -38,20 +38,21 @@ namespace Visitz.Services
 
         protected override async Task RunApiServiceAsync()
         {
-            await SubmitNote(Payload);
-            await GetNotes(Payload.EntityNumber, Payload.EntityType);
-            ResultCode = Result.Successful;
+            if (await SubmitNote(Payload) && await GetNotes(Payload.EntityNumber, Payload.EntityType))
+                ResultCode = Result.Successful;
         }
 
-        private async Task SubmitNote(SubmitNoteEntity noteEntity)
+        private async Task<bool> SubmitNote(SubmitNoteEntity noteEntity)
         {
-            await ServiceHandler.TryRunServiceAsync(SubmitNoteService.MakeStartMessage(noteEntity));
+            var result = await ServiceHandler.TryRunServiceAsync(SubmitNoteService.MakeStartMessage(noteEntity));
+            return result == Result.Successful;
         }
 
-        private async Task GetNotes(string caseIncidentId, string entityType)
+        private async Task<bool> GetNotes(string caseIncidentId, string entityType)
         {
             var startMessage = GetNotesService.MakeStartMessage(caseIncidentId, entityType);
-            await ServiceHandler.TryRunServiceAsync(startMessage);
+            var result = await ServiceHandler.TryRunServiceAsync(startMessage);
+            return result == Result.Successful;
         }
     }
 }

--- a/visitz/Visitz/Services/SubmitNoteService.cs
+++ b/visitz/Visitz/Services/SubmitNoteService.cs
@@ -31,7 +31,7 @@ namespace Visitz.Services
             return MakeId(Payload.EntityNumber, Payload.NotePeriod);
         }
 
-        protected override async Task RunAsync()
+        protected override async Task RunApiServiceAsync()
         {
             if (DebugOptions.DryFireSubmitNotes)
             {

--- a/visitz/Visitz/Services/VisitzApiService.cs
+++ b/visitz/Visitz/Services/VisitzApiService.cs
@@ -18,8 +18,8 @@ namespace Visitz.Services
         {
             try
             {
-                if (await VisitzSession.GetValidSessionAsync())
                     await base.OnRunAsync();
+                if (await VisitzSession.TryGetValidSessionAsync())
             }
             catch (VisitzApiException ex)
             {

--- a/visitz/Visitz/Services/VisitzApiService.cs
+++ b/visitz/Visitz/Services/VisitzApiService.cs
@@ -16,10 +16,11 @@ namespace Visitz.Services
 
         public override async Task OnRunAsync()
         {
+            await VisitzSession.AssertValidSessionAsync();
+
             try
             {
                     await base.OnRunAsync();
-                if (await VisitzSession.TryGetValidSessionAsync())
             }
             catch (VisitzApiException ex)
             {

--- a/visitz/Visitz/Services/VisitzApiService.cs
+++ b/visitz/Visitz/Services/VisitzApiService.cs
@@ -15,13 +15,13 @@ namespace Visitz.Services
             Vpi = vpi;
         }
 
-        public override async Task OnRunAsync()
+        protected override sealed async Task RunServiceAsync()
         {
             await VisitzSession.AssertValidSessionAsync();
 
             try
             {
-                    await base.OnRunAsync();
+                await RunApiServiceAsync();
             }
             catch (VisitzApiException ex)
             {

--- a/visitz/Visitz/Services/VisitzApiService.cs
+++ b/visitz/Visitz/Services/VisitzApiService.cs
@@ -1,5 +1,6 @@
 ﻿using System.Net;
 using Visitz.Authentication.Keycloak;
+using Visitz.Resources.Localization;
 using VisitzApi;
 using VisitzApi.ErrorHandling;
 
@@ -28,17 +29,24 @@ namespace Visitz.Services
                 Console.WriteLine(nameof(VisitzApiException) 
                     + $" {ex.HttpStatusCode} -> {ex.Message}:\n{ex.StackTrace}");
 #endif
-
-                if (ex.HttpStatusCode == HttpStatusCode.Unauthorized
-                    || ex.HttpStatusCode == HttpStatusCode.Forbidden)
+                if (IsSessionException(ex.HttpStatusCode))
                 {
                     await VisitzSession.InvalidateSessionAsync();
-                    ResultMessage = ex.Message;
+                    throw new UnauthorizedAccessException(LocalizedStrings.UnauthorizedForApi, ex);
 
-                    // TODO: Properly notify user their session is invalid and
-                    // prompt them to login again
+                    // No need for different messages for 401 vs. 403, since 401 would've been handled by the
+                    // OAuth login.
                 }
+
+                throw;
             }
+        }
+
+        protected abstract Task RunApiServiceAsync();
+
+        private static bool IsSessionException(HttpStatusCode code)
+        {
+            return code == HttpStatusCode.Unauthorized || code == HttpStatusCode.Forbidden;
         }
     }
 }

--- a/visitz/Visitz/Services/VisitzService.cs
+++ b/visitz/Visitz/Services/VisitzService.cs
@@ -28,6 +28,11 @@ namespace Visitz.Services
             /// A service was unable to complete its tasks.
             /// </summary>
             Error = 1,
+
+            /// <summary>
+            /// A service was requested to run but it was already running.
+            /// </summary>
+            NoOperation = 2,
         }
 
         public State Status { get; protected set; }

--- a/visitz/Visitz/Services/VisitzService.cs
+++ b/visitz/Visitz/Services/VisitzService.cs
@@ -68,17 +68,30 @@ namespace Visitz.Services
 
         public abstract string GetId();
 
-        public virtual async Task OnRunAsync()
+        public async Task RunAsync()
         {
             PublishCurrentState(State.Running);
-            await RunAsync();
+
+            try
+            {
+                await RunServiceAsync();
+            }
+            catch (Exception ex)
+            {
+                ResultCode = Result.Error;
+                ResultMessage = ex.Message;
+
+                throw;
+            }
         }
 
-        public virtual async Task OnFinishAsync()
+        protected abstract Task RunServiceAsync();
+
+        public async Task FinishAsync()
         {
             try
             {
-                await FinishAsync();
+                await FinishServiceAsync();
             }
             finally
             {
@@ -86,12 +99,7 @@ namespace Visitz.Services
             }
         }
 
-        protected virtual Task RunAsync()
-        {
-            return Task.CompletedTask;
-        }
-
-        protected virtual Task FinishAsync()
+        protected virtual Task FinishServiceAsync()
         {
             return Task.CompletedTask;
         }

--- a/visitz/Visitz/Services/VisitzService.cs
+++ b/visitz/Visitz/Services/VisitzService.cs
@@ -33,9 +33,9 @@ namespace Visitz.Services
         public State Status { get; protected set; }
 
         // Services must explicitly set ResultCode when they complete their tasks.
-        protected Result ResultCode { get; set; } = Result.Error;
+        public Result ResultCode { get; protected set; } = Result.Error;
 
-        protected string ResultMessage { get; set; }
+        public string ResultMessage { get; protected set; }
 
         public object Payload { get; set; }
 

--- a/visitz/Visitz/ViewModels/NotePublishViewModel.cs
+++ b/visitz/Visitz/ViewModels/NotePublishViewModel.cs
@@ -88,13 +88,13 @@ namespace Visitz.ViewModels
             noteEntity.Content = NoteItem.WrapContent(info.Idir, DateTime.Now, draft);
             noteEntity.CreatedBy = info.Idir;
 
-            WeakReferenceMessenger.Default.Send(SubmitAndGetNotesService.MakeStartMessage(noteEntity));
-
             ShowPublishingIndicator = true;
             ShowRefreshIndicator = false;
             PublishingStatus = LocalizedStrings.PublishingNotesToIcm;
             ShowRefreshSection = false;
             ShowRetrySection = false;
+
+            WeakReferenceMessenger.Default.Send(SubmitAndGetNotesService.MakeStartMessage(noteEntity));
         }
 
         public async void Receive(ServiceStateMessage message)

--- a/visitz/Visitz/ViewModels/SessionViewModel.cs
+++ b/visitz/Visitz/ViewModels/SessionViewModel.cs
@@ -90,10 +90,19 @@ public partial class SessionViewModel
     [RelayCommand]
     public async void LoginAsync()
     {
-        if (await VisitzSession.LoginAsync() && SessionInfo.HasBasicAccessRole)
+        try
         {
-            await VisitzApp.Navigation.PopModalAsync();
-            WeakReferenceMessenger.Default.Send(GetAllDataForOfflineService.MakeStartMessage());
+            await VisitzSession.LoginAsync();
+
+            if (SessionInfo.HasBasicAccessRole)
+            {
+                await VisitzApp.Navigation.PopModalAsync();
+                WeakReferenceMessenger.Default.Send(GetAllDataForOfflineService.MakeStartMessage());
+            }
+        }
+        catch
+        {
+            // TODO: log or show error
         }
     }
 }

--- a/visitz/Visitz/Views/InternetInfoView.xaml
+++ b/visitz/Visitz/Views/InternetInfoView.xaml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Visitz.Views"
+             x:Class="Visitz.Views.InternetInfoView"
+             x:DataType="views:InternetInfoView"
+             IsVisible="{Binding ShouldShowView}">
+
+    <HorizontalStackLayout Spacing="5">
+        
+        <Image
+            VerticalOptions="Center"
+            Source="{Binding ImageSource}" />
+        
+        <Label 
+            VerticalOptions="Center" 
+            Text="{Binding Message}"
+            TextColor="{Binding Color}" />
+        
+    </HorizontalStackLayout>
+    
+</ContentView>

--- a/visitz/Visitz/Views/InternetInfoView.xaml.cs
+++ b/visitz/Visitz/Views/InternetInfoView.xaml.cs
@@ -1,0 +1,105 @@
+using Microsoft.Maui.Graphics.Text;
+using Microsoft.Maui.Networking;
+using Visitz.Extensions;
+using Visitz.FontIcons;
+using Visitz.Resources.Localization;
+
+namespace Visitz.Views;
+
+public partial class InternetInfoView : ContentView
+{
+    public static readonly BindableProperty ShouldShowViewProperty =
+        BindableProperty.Create(nameof(ShouldShowView), typeof(bool), typeof(InternetInfoView));
+
+    public static readonly BindableProperty MessageProperty =
+        BindableProperty.Create(nameof(Message), typeof(string), typeof(InternetInfoView));
+
+    public static readonly BindableProperty ImageSourceProperty =
+        BindableProperty.Create(nameof(ImageSource), typeof(ImageSource), typeof(InternetInfoView));
+
+    public static readonly BindableProperty ColorProperty =
+        BindableProperty.Create(nameof(Color), typeof(Color), typeof(TagView));
+
+    public bool ShouldShowView
+    {
+        get => (bool)GetValue(ShouldShowViewProperty);
+        set => SetValue(ShouldShowViewProperty, value);
+    }
+
+    public string Message
+    {
+        get => (string)GetValue(MessageProperty);
+        set => SetValue(MessageProperty, value);
+    }
+
+    public ImageSource ImageSource
+    {
+        get => (ImageSource)GetValue(ImageSourceProperty);
+        set => SetValue(ImageSourceProperty, value);
+    }
+
+    public Color Color
+    {
+        get => (Color)GetValue(ColorProperty);
+        set => SetValue(ColorProperty, value);
+    }
+
+    public InternetInfoView()
+	{
+		InitializeComponent();
+        BindingContext = this;
+	}
+
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+
+        ApplyConnectivityStyles(Connectivity.Current.NetworkAccess);
+    }
+
+    protected override void OnParentChanging(ParentChangingEventArgs args)
+    {
+        base.OnParentChanging(args);
+
+        if (args.AttachingToParent())
+            Connectivity.Current.ConnectivityChanged += Current_ConnectivityChanged;
+
+        else if (args.DetachingFromParent())
+            Connectivity.Current.ConnectivityChanged -= Current_ConnectivityChanged;
+    }
+
+    private void Current_ConnectivityChanged(object sender, ConnectivityChangedEventArgs e)
+    {
+        ApplyConnectivityStyles(e.NetworkAccess);
+    }
+
+    private void ApplyConnectivityStyles(NetworkAccess networkAccess)
+    {
+        ShouldShowView = networkAccess != NetworkAccess.Internet;
+
+        Message = LocalizedStrings.NoInternet;
+        Color = Colors.Red;
+        ImageSource = MaterialIcons.Signal_disconnected.GetUnfilledMaterialIcon(Color);
+    }
+
+    // REVIEW: We *could* show a more meaningful message when connected without internet, but it turns out
+    // that trying to use yellow on a whitebackground is an awful undertaking.
+    private void LocalNetworkStyles(NetworkAccess networkAccess)
+    {
+        switch (networkAccess)
+        {
+            case NetworkAccess.Unknown:
+            case NetworkAccess.ConstrainedInternet:
+            case NetworkAccess.None:
+                Message = LocalizedStrings.NoInternet;
+                Color = Colors.Red;
+                ImageSource = MaterialIcons.Signal_disconnected.GetUnfilledMaterialIcon(Color);
+                break;
+            case NetworkAccess.Local:
+                Message = LocalizedStrings.ConnectedNoInternet;
+                Color = Color.FromArgb("#ccb800");
+                ImageSource = FluentIcons.Wifi_warning_20_regular.GetFluentIcon(Color);
+                break;
+        }
+    }
+}

--- a/visitz/Visitz/Views/InternetInfoView.xaml.cs
+++ b/visitz/Visitz/Views/InternetInfoView.xaml.cs
@@ -83,7 +83,7 @@ public partial class InternetInfoView : ContentView
     }
 
     // REVIEW: We *could* show a more meaningful message when connected without internet, but it turns out
-    // that trying to use yellow on a whitebackground is an awful undertaking.
+    // that trying to use yellow on a white background is an awful undertaking.
     private void LocalNetworkStyles(NetworkAccess networkAccess)
     {
         switch (networkAccess)

--- a/visitz/Visitz/Visitz.csproj
+++ b/visitz/Visitz/Visitz.csproj
@@ -193,6 +193,9 @@
 	  <MauiXaml Update="Pages\DebugOptionsPage.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
+	  <MauiXaml Update="Views\InternetInfoView.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
 	  <MauiXaml Update="Views\RightChevronIconView.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>


### PR DESCRIPTION
Show feedback and prevent the user from initiating the submit notes process.

This PR includes changes to the Login/Refresh mechanism. It now uses exceptions instead of opaque Boolean return values.

This PR also includes changes to how Services work when implemented. Instead of overriding "RunAsync" and ServiceHandler invoking "OnRunAsync", services now use a staggered mechanism:

1. ServiceHandler calls VisitzService.RunAsync()
2. VisitzService.RunAsync() calls [abstract] VisitzService.RunServiceAsync()

Inheritors (in this case, VisitzApiService):

3. VisitzApiService overrides VisitzService.RunServiceAsync()
4. VisitzApiService.RunServiceAsync() calls [abstract] VisitzApiService.RunApiServiceAsync()
5. e.g. SubmiteNotesService overrides VisitzApiService.RunApiServiceAsync()
6. SubmiteNotesService.RunApiServiceAsync() performs work

This change has been made so services at varying levels can more easily perform their own exception catching.