### PR TITLE
Fix caseload handling

### DIFF
--- a/visitz/VisitzApi/ErrorHandling/VisitzApiException.cs
+++ b/visitz/VisitzApi/ErrorHandling/VisitzApiException.cs
@@ -10,28 +10,14 @@ namespace VisitzApi.ErrorHandling
 
         public bool IsError => IsErroneousStatus(HttpStatusCode) || Message.Length > 0;
 
-        private VisitzApiException(HttpStatusCode statusCode, string errorMessage) : base(errorMessage)
+        internal VisitzApiException(HttpStatusCode statusCode, string errorMessage) : base(errorMessage)
         {
             HttpStatusCode = statusCode;
         }
 
-        private static bool IsErroneousStatus(HttpStatusCode statusCode)
+        internal static bool IsErroneousStatus(HttpStatusCode statusCode)
         {
             return (int)statusCode >= 400;
-        }
-
-        internal static void ThrowIfInvalid(HttpResponseMessage response, string content)
-        {
-            if (IsErroneousStatus(response.StatusCode))
-            {
-                if (!KongJsonMessage.TryFindMessage(content, out string message))
-                    message = content;
-
-                throw new VisitzApiException(response.StatusCode, message);
-            }
-
-            else if (WebMethodsJsonError.TryFindFirstError(content, out string errorMessage))
-                throw new VisitzApiException(response.StatusCode, errorMessage);
         }
     }
 }

--- a/visitz/VisitzApi/Requests/GetCaseloadEndpoint.cs
+++ b/visitz/VisitzApi/Requests/GetCaseloadEndpoint.cs
@@ -1,6 +1,7 @@
 ﻿using VisitzApi.Models;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using VisitzApi.ErrorHandling;
 
 namespace VisitzApi.Requests
 {
@@ -15,6 +16,8 @@ namespace VisitzApi.Requests
 
         private static readonly string ListCaseIncidentKey = "listCaseIncident";
         private static readonly string ListCaseIncidentsListKey = "listCaseIncidents";
+
+        private static readonly string NoRecordsFoundError = "No records found";
 
         private readonly string[] _workerIds;
 
@@ -59,8 +62,23 @@ namespace VisitzApi.Requests
             };
         }
 
+        public override void ThrowOnWebMethodsErrors(HttpResponseMessage response, string content)
+        {
+            if (WebMethodsJsonError.TryFindFirstError(content, out string errorMessage))
+            {
+                // Because of questionable API design, we're treating this "No records found" message as the equivalent
+                // of an HTTP 200 empty reponse. Any other error message should trigger an exception.
+                if (errorMessage != NoRecordsFoundError)
+                    throw new VisitzApiException(response.StatusCode, errorMessage);
+            }
+        }
+
         public override IEnumerable<CaseloadEntity> HandleResponse(string responseContent)
         {
+            if (WebMethodsJsonError.TryFindFirstError(responseContent, out string errorMessage))
+                if (errorMessage == NoRecordsFoundError)
+                    return new List<CaseloadEntity>();
+
             var caseloadJson = JsonDocument.Parse(responseContent)
                 .RootElement
                 .GetProperty(ListCaseIncidentKey)

--- a/visitz/VisitzApi/Requests/VisitzBaseEndpoint.cs
+++ b/visitz/VisitzApi/Requests/VisitzBaseEndpoint.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections;
+using VisitzApi.ErrorHandling;
 
 namespace VisitzApi.Requests
 {
@@ -30,6 +31,23 @@ namespace VisitzApi.Requests
         }
 
         public abstract HttpRequestMessage MakeRequest();
+
+        public virtual void ThrowOnHttpErrors(HttpResponseMessage response, string content)
+        {
+            if (VisitzApiException.IsErroneousStatus(response.StatusCode))
+            {
+                if (!KongJsonMessage.TryFindMessage(content, out string message))
+                    message = content;
+
+                throw new VisitzApiException(response.StatusCode, message);
+            }
+        }
+
+        public virtual void ThrowOnWebMethodsErrors(HttpResponseMessage response, string content)
+        {
+            if (WebMethodsJsonError.TryFindFirstError(content, out string errorMessage))
+                throw new VisitzApiException(response.StatusCode, errorMessage);
+        }
 
         public abstract ResponseType HandleResponse(string responseContent);
     }

--- a/visitz/VisitzApi/Vpi.cs
+++ b/visitz/VisitzApi/Vpi.cs
@@ -24,7 +24,8 @@ namespace VisitzApi
             var response = await HttpClient.SendAsync(endpoint.MakeRequest());
             string content = await response.Content.ReadAsStringAsync();
 
-            VisitzApiException.ThrowIfInvalid(response, content);
+            endpoint.ThrowOnHttpErrors(response, content);
+            endpoint.ThrowOnWebMethodsErrors(response, content);
 
             return endpoint.HandleResponse(content);
         }


### PR DESCRIPTION
Modified API error parsing to instead be default, virtual functions. This way they can be overridden per request if necessary.

Then, applied this new logic to the caseload API—discarding the "No records found" "error" in favour of a successful empty response.