### PR TITLE
Fix realm paths

### DIFF
--- a/visitz/Visitz/Storage/VisitzRealm.cs
+++ b/visitz/Visitz/Storage/VisitzRealm.cs
@@ -8,11 +8,11 @@ public class VisitzRealm
     public static readonly string IcmDataCopiesPath = "icmDataCopies.realm";
     public static readonly string NoteDraftRealmPath = "noteDraftRealm.realm";
 
-    private static async Task<Realm> GetInstanceAsync(string path)
+    private static async Task<Realm> GetInstanceAsync(string realmFilename)
     {
-        return await Realm.GetInstanceAsync(new RealmConfiguration(path)
+        return await Realm.GetInstanceAsync(new RealmConfiguration(realmFilename)
         {
-            EncryptionKey = await VisitzKey.GetKey(path),
+            EncryptionKey = await VisitzKey.GetKey(realmFilename),
 #if DEBUG
             ShouldDeleteIfMigrationNeeded = true
 #endif

--- a/visitz/Visitz/Storage/VisitzRealm.cs
+++ b/visitz/Visitz/Storage/VisitzRealm.cs
@@ -8,15 +8,24 @@ public class VisitzRealm
     public static readonly string IcmDataCopiesPath = "icmDataCopies.realm";
     public static readonly string NoteDraftRealmPath = "noteDraftRealm.realm";
 
-    private static async Task<Realm> GetInstanceAsync(string realmFilename)
+    private static async Task<RealmConfiguration> MakeConfigAsync(string realmPath)
     {
-        return await Realm.GetInstanceAsync(new RealmConfiguration(realmFilename)
+        return new RealmConfiguration(realmPath)
         {
-            EncryptionKey = await VisitzKey.GetKey(realmFilename),
+            EncryptionKey = await VisitzKey.GetKey(realmPath),
 #if DEBUG
             ShouldDeleteIfMigrationNeeded = true
 #endif
-        });
+        };
+    }
+
+    private static async Task<Realm> GetInstanceAsync(string realmFilename)
+    {
+        var realmConfig = await MakeConfigAsync(realmFilename);
+
+        ConsoleTrace.TraceMethod(typeof(VisitzRealm), $"GetInstanceAsync('{realmConfig.DatabasePath}')");
+
+        return await Realm.GetInstanceAsync(realmConfig);
     }
 
     private static async Task<Realm> ErrorNewInstanceAsync(string path, Exception ex)

--- a/visitz/Visitz/Storage/VisitzRealm.cs
+++ b/visitz/Visitz/Storage/VisitzRealm.cs
@@ -1,6 +1,10 @@
 ﻿using Realms;
 using Realms.Exceptions;
 
+#if WINDOWS
+using MauiFileSystem = Microsoft.Maui.Storage.FileSystem;
+#endif
+
 namespace Visitz.Storage;
 
 public class VisitzRealm
@@ -21,8 +25,14 @@ public class VisitzRealm
 
     private static async Task<Realm> GetInstanceAsync(string realmFilename)
     {
+#if WINDOWS
+        var realmPath = Path.Combine(MauiFileSystem.Current.AppDataDirectory, realmFilename);
+        var realmConfig = await MakeConfigAsync(realmPath);
+#else
+        // For non-Windows builds, we'll continue to get the Realm file using the default path that
+        // Realm provides (for backwards capability).
         var realmConfig = await MakeConfigAsync(realmFilename);
-
+#endif
         ConsoleTrace.TraceMethod(typeof(VisitzRealm), $"GetInstanceAsync('{realmConfig.DatabasePath}')");
 
         return await Realm.GetInstanceAsync(realmConfig);


### PR DESCRIPTION
Added Windows-specific logic to use the AppData folder instead of Realm's default (/system32).