### PR TITLE
Fix null DOB Age calculation

### DIFF
--- a/visitz/VisitzModel/Extensions/DateTimeExtensions.cs
+++ b/visitz/VisitzModel/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,8 @@
+namespace VisitzModel.Extensions;
+
+internal static class DateTimeExtensions
+{
+#pragma warning disable SS002 // DateTime.Now was referenced
+	public static DateTime LocalNow => DateTime.Now;
+#pragma warning restore SS002 // DateTime.Now was referenced
+}

--- a/visitz/VisitzModel/Models/FamilyMember.cs
+++ b/visitz/VisitzModel/Models/FamilyMember.cs
@@ -1,4 +1,4 @@
-﻿using Realms;
+using Realms;
 using VisitzApi.Models;
 using VisitzModel.Extensions;
 
@@ -44,9 +44,13 @@ namespace VisitzModel.Models
             .TrimEnd([',', ' ', '-'])
             .TrimEnd([',', ' ', '-']);
 
-        public int Age => (DateTime.Now - DateTime.Parse(DateOfBirth)).Days / 365;
+#pragma warning disable SS003 // The operands of a divisive expression are both integers and result in an implicit rounding.
+		public int Age => DateTime.TryParse(DateOfBirth, out DateTime dateOfBirth)
+					? (DateTimeExtensions.LocalNow - dateOfBirth).Days / 365 // Integer division is intentional
+					: 0;
+#pragma warning restore SS003 // The operands of a divisive expression are both integers and result in an implicit rounding.
 
-        public static FamilyMember FromApiEntity(FamilyMemberEntity familyMember)
+		public static FamilyMember FromApiEntity(FamilyMemberEntity familyMember)
         {
             return new FamilyMember()
             {

--- a/visitz/VisitzModel/Models/FamilyMember.cs
+++ b/visitz/VisitzModel/Models/FamilyMember.cs
@@ -45,9 +45,9 @@ namespace VisitzModel.Models
             .TrimEnd([',', ' ', '-']);
 
 #pragma warning disable SS003 // The operands of a divisive expression are both integers and result in an implicit rounding.
-		public int Age => DateTime.TryParse(DateOfBirth, out DateTime dateOfBirth)
+		public int? Age => DateTime.TryParse(DateOfBirth, out DateTime dateOfBirth)
 					? (DateTimeExtensions.LocalNow - dateOfBirth).Days / 365 // Integer division is intentional
-					: 0;
+					: null;
 #pragma warning restore SS003 // The operands of a divisive expression are both integers and result in an implicit rounding.
 
 		public static FamilyMember FromApiEntity(FamilyMemberEntity familyMember)

--- a/visitz/VisitzModelTest/Models/FamilyMemberTests.cs
+++ b/visitz/VisitzModelTest/Models/FamilyMemberTests.cs
@@ -12,14 +12,14 @@ public class FamilyMemberTests
 	[InlineData("2020-05-54")]
 	[InlineData("2020-13-01")]
 	[InlineData("-2020-05-01")]
-	public void AgeZeroWhenDateOfBirthIsInvalidValue(string dateOfBirth)
+	public void AgeNullWhenDateOfBirthIsInvalidValue(string dateOfBirth)
 	{
 		FamilyMember member = new()
 		{
 			DateOfBirth = dateOfBirth
 		};
 
-		Assert.Equal(0, member.Age);
+		Assert.Null(member.Age);
 	}
 
 	[Theory]

--- a/visitz/VisitzModelTest/Models/FamilyMemberTests.cs
+++ b/visitz/VisitzModelTest/Models/FamilyMemberTests.cs
@@ -1,0 +1,43 @@
+using VisitzModel.Models;
+
+namespace VisitzModelTest.Models;
+
+public class FamilyMemberTests
+{
+	[Theory]
+	[InlineData(null)]
+	[InlineData("")]
+	[InlineData("    ")]
+	[InlineData("this isn't a date")]
+	[InlineData("2020-05-54")]
+	[InlineData("2020-13-01")]
+	[InlineData("-2020-05-01")]
+	public void AgeZeroWhenDateOfBirthIsInvalidValue(string dateOfBirth)
+	{
+		FamilyMember member = new()
+		{
+			DateOfBirth = dateOfBirth
+		};
+
+		Assert.Equal(0, member.Age);
+	}
+
+	[Theory]
+	[InlineData("1800-01-01")]
+	[InlineData("1950-01-01")]
+	[InlineData("2000-01-01")]
+	[InlineData("2500-01-01")]
+	public void AgeIsCorrectByDate(string dateOfBirth)
+	{
+		var dob = DateTime.Parse(dateOfBirth);
+		var dateDiff = DateTime.Now - dob;
+		var expectedAge = dateDiff.Days / 365;
+
+		FamilyMember member = new()
+		{
+			DateOfBirth = dateOfBirth
+		};
+
+		Assert.Equal(expectedAge, member.Age);
+	}
+}


### PR DESCRIPTION
[STRY0028537 - Fix crashing issue when a Contact's date of birth is empty](https://bcsocialsector.service-now.com/rm_story.do?sys_id=60590ceb87eccad03b837446dabb35ee&sysparm_view=&sysparm_time=1710346512770)