### PR TITLE
Fix "all clear" message layout

### DIFF
--- a/visitz/Visitz/Views/Caseload/CaseloadView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadView.xaml
@@ -183,7 +183,10 @@
                         SelectionMode="None"
                         ItemSizingStrategy="MeasureFirstItem">
                         <CollectionView.EmptyView>
-                            <VerticalStackLayout HorizontalOptions="Center" Padding="20" Spacing="10">
+                            <VerticalStackLayout
+								HorizontalOptions="Fill"
+								Padding="20"
+								Spacing="10">
                                 <Label 
                                     HorizontalOptions="Center"
 									HorizontalTextAlignment="Center"

--- a/visitz/Visitz/Views/Caseload/CaseloadView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadView.xaml
@@ -150,17 +150,15 @@
                 AbsoluteLayout.LayoutBounds="0.5,0.5,1,-1"
                 Spacing="40"
                 IsVisible="{Binding ShowEmptyCaseloadMessage}">
-                <Image HorizontalOptions="Center">
-                    <Image.Source>
-                        <FontImageSource 
-							Glyph="{Static icons:FluentIcons.Clipboard_task_list_ltr_20_filled}"
-							FontFamily="FluentIconsRegular"
-							Color="{StaticResource Primary}"
-							Size="160"/>
-                    </Image.Source>
-                </Image>
+				<Label
+					HorizontalOptions="Center"
+					FontAutoScalingEnabled="False"
+					FontFamily="FluentIconsRegular"
+					FontSize="160"
+					TextColor="{StaticResource Primary}"
+					Text="{Static icons:FluentIcons.Clipboard_task_list_ltr_20_filled}" />
 
-                <Label
+				<Label
 					HorizontalOptions="Center"
 					HorizontalTextAlignment="Center"
                     FontSize="20"

--- a/visitz/Visitz/Views/Caseload/CaseloadView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadView.xaml
@@ -146,8 +146,8 @@
         <AbsoluteLayout VerticalOptions="FillAndExpand">
 
             <VerticalStackLayout
-                AbsoluteLayout.LayoutFlags="PositionProportional"
-                AbsoluteLayout.LayoutBounds=".5,.5"
+                AbsoluteLayout.LayoutFlags="XProportional,YProportional,WidthProportional"
+                AbsoluteLayout.LayoutBounds="0.5,0.5,1,-1"
                 Spacing="40"
                 IsVisible="{Binding ShowEmptyCaseloadMessage}">
                 <Image>

--- a/visitz/Visitz/Views/Caseload/CaseloadView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadView.xaml
@@ -148,7 +148,7 @@
             <VerticalStackLayout
                 AbsoluteLayout.LayoutFlags="XProportional,YProportional,WidthProportional"
                 AbsoluteLayout.LayoutBounds="0.5,0.5,1,-1"
-                Spacing="40"
+                Spacing="{OnPlatform WinUI=0, Default=40}"
                 IsVisible="{Binding ShowEmptyCaseloadMessage}">
 				<Label
 					HorizontalOptions="Center"

--- a/visitz/Visitz/Views/Caseload/CaseloadView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadView.xaml
@@ -150,17 +150,19 @@
                 AbsoluteLayout.LayoutBounds="0.5,0.5,1,-1"
                 Spacing="40"
                 IsVisible="{Binding ShowEmptyCaseloadMessage}">
-                <Image>
+                <Image HorizontalOptions="Center">
                     <Image.Source>
                         <FontImageSource 
-                        Glyph="{Static icons:FluentIcons.Clipboard_task_list_ltr_20_filled}"
-                        FontFamily="FluentIconsRegular"
-                        Color="{StaticResource Primary}"
-                        Size="160"/>
+							Glyph="{Static icons:FluentIcons.Clipboard_task_list_ltr_20_filled}"
+							FontFamily="FluentIconsRegular"
+							Color="{StaticResource Primary}"
+							Size="160"/>
                     </Image.Source>
                 </Image>
 
                 <Label
+					HorizontalOptions="Center"
+					HorizontalTextAlignment="Center"
                     FontSize="20"
                     Text="{local:Localize CaseloadIsEmpty}" />
             </VerticalStackLayout>
@@ -186,6 +188,7 @@
                             <VerticalStackLayout HorizontalOptions="Center" Padding="20" Spacing="10">
                                 <Label 
                                     HorizontalOptions="Center"
+									HorizontalTextAlignment="Center"
                                     FontSize="16"
                                     Text="{Binding CollectionViewPrompt}" />
 


### PR DESCRIPTION
[STRY0027445 - UI issue: empty caseload "All clear" text is cut off in portrait mode](https://bcsocialsector.service-now.com/rm_story.do?sys_id=fd30cf0a1b080ad05b04ed72b24bcbad&sysparm_view=&sysparm_time=1711145783063)