### PR TITLE
Fix caseload list item resizing

### DIFF
--- a/visitz/Visitz/Views/Caseload/CaseloadItemView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadItemView.xaml
@@ -7,7 +7,7 @@
     xmlns:models="clr-namespace:VisitzModel.Models;assembly=VisitzModel"
     xmlns:viewmodels="clr-namespace:Visitz.ViewModels"
     xmlns:tagview="clr-namespace:Visitz.Views.TagViews"
-    x:Class="Visitz.Views.CaseloadItemView"
+    x:Class="Visitz.Views.Caseload.CaseloadItemView"
     x:DataType="models:CaseloadItem">
 
     <ContentView.GestureRecognizers>

--- a/visitz/Visitz/Views/Caseload/CaseloadItemView.xaml.cs
+++ b/visitz/Visitz/Views/Caseload/CaseloadItemView.xaml.cs
@@ -1,6 +1,6 @@
 using VisitzModel.Models;
 
-namespace Visitz.Views;
+namespace Visitz.Views.Caseload;
 
 public partial class CaseloadItemView : ContentView
 {

--- a/visitz/Visitz/Views/Caseload/CaseloadView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadView.xaml
@@ -165,58 +165,49 @@
                     Text="{local:Localize CaseloadIsEmpty}" />
             </VerticalStackLayout>
 
-            <RefreshView
+			<RefreshView
                 AbsoluteLayout.LayoutFlags="All"
                 AbsoluteLayout.LayoutBounds="0,0,1,1"
                 Command="{Binding RefreshCaseloadCommand}"
                 IsRefreshing="{Binding IsRefreshing}">
 
-                <!-- 
-                    WORKAROUND (iOS): Wrap CollectionView with ContentView when using it with a RefreshView.
-                    Is a workaround-solution for https://github.com/dotnet/maui/issues/7315#issuecomment-1320706188
-                    This is supposedly fixed in .NET 8, so when we upgrade we can remove this wrapper ContentView.
-                -->
-                <ContentView>
+				<CollectionView
+                    ItemsSource="{Binding Caseload}"
+                    SelectionMode="None"
+                    ItemSizingStrategy="MeasureFirstItem">
+                    <CollectionView.EmptyView>
+                        <VerticalStackLayout
+							HorizontalOptions="Fill"
+							Padding="20"
+							Spacing="10">
+                            <Label 
+                                HorizontalOptions="Center"
+								HorizontalTextAlignment="Center"
+                                FontSize="16"
+                                Text="{Binding CollectionViewPrompt}" />
 
-                    <CollectionView
-                        ItemsSource="{Binding Caseload}"
-                        SelectionMode="None"
-                        ItemSizingStrategy="MeasureFirstItem">
-                        <CollectionView.EmptyView>
-                            <VerticalStackLayout
-								HorizontalOptions="Fill"
-								Padding="20"
-								Spacing="10">
-                                <Label 
-                                    HorizontalOptions="Center"
-									HorizontalTextAlignment="Center"
-                                    FontSize="16"
-                                    Text="{Binding CollectionViewPrompt}" />
-
-                                <Label 
-                                    HorizontalOptions="Center" 
-                                    FontSize="24"
-                                    Text="↓" />
-                            </VerticalStackLayout>
-                        </CollectionView.EmptyView>
-                        <CollectionView.ItemsLayout>
-                            <!-- 
-                                FIXME: use VerticalItemSpacing. Currently not using it because of a layout issue:
-                                When dynamically changing the ItemsSource binding, the bottom of the CollectionView
-                                has varying amounts of whitespace from the VerticalItemSpacing attribute. Removing
-                                VerticalItemSpacing and dynamically changing the ItemsSource binding operates as 
-                                expected. 
-                            -->
-                            <GridItemsLayout Orientation="Vertical" Span="1" />
-                        </CollectionView.ItemsLayout>
-                        <CollectionView.ItemTemplate>
-                            <DataTemplate x:DataType="models:CaseloadItem">
-                                <caseload:CaseloadItemView />
-                            </DataTemplate>
-                        </CollectionView.ItemTemplate>
-                    </CollectionView>
-
-                </ContentView>
+                            <Label 
+                                HorizontalOptions="Center" 
+                                FontSize="24"
+                                Text="↓" />
+                        </VerticalStackLayout>
+                    </CollectionView.EmptyView>
+                    <CollectionView.ItemsLayout>
+                        <!-- 
+                            FIXME: use VerticalItemSpacing. Currently not using it because of a layout issue:
+                            When dynamically changing the ItemsSource binding, the bottom of the CollectionView
+                            has varying amounts of whitespace from the VerticalItemSpacing attribute. Removing
+                            VerticalItemSpacing and dynamically changing the ItemsSource binding operates as 
+                            expected. 
+                        -->
+                        <GridItemsLayout Orientation="Vertical" Span="1" />
+                    </CollectionView.ItemsLayout>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:CaseloadItem">
+                            <caseload:CaseloadItemView />
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
 
             </RefreshView>
 

--- a/visitz/Visitz/Views/Caseload/CaseloadView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadView.xaml
@@ -211,7 +211,7 @@
                         </CollectionView.ItemsLayout>
                         <CollectionView.ItemTemplate>
                             <DataTemplate x:DataType="models:CaseloadItem">
-                                <views:CaseloadItemView />
+                                <caseload:CaseloadItemView />
                             </DataTemplate>
                         </CollectionView.ItemTemplate>
                     </CollectionView>

--- a/visitz/Visitz/Views/Caseload/CaseloadView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadView.xaml
@@ -175,6 +175,7 @@
                     ItemsSource="{Binding Caseload}"
                     SelectionMode="None"
                     ItemSizingStrategy="MeasureFirstItem">
+					
                     <CollectionView.EmptyView>
                         <VerticalStackLayout
 							HorizontalOptions="Fill"
@@ -192,21 +193,17 @@
                                 Text="↓" />
                         </VerticalStackLayout>
                     </CollectionView.EmptyView>
-                    <CollectionView.ItemsLayout>
-                        <!-- 
-                            FIXME: use VerticalItemSpacing. Currently not using it because of a layout issue:
-                            When dynamically changing the ItemsSource binding, the bottom of the CollectionView
-                            has varying amounts of whitespace from the VerticalItemSpacing attribute. Removing
-                            VerticalItemSpacing and dynamically changing the ItemsSource binding operates as 
-                            expected. 
-                        -->
-                        <GridItemsLayout Orientation="Vertical" Span="1" />
+					
+					<CollectionView.ItemsLayout>
+						<LinearItemsLayout Orientation="Vertical" />
                     </CollectionView.ItemsLayout>
+					
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="models:CaseloadItem">
                             <caseload:CaseloadItemView />
                         </DataTemplate>
                     </CollectionView.ItemTemplate>
+					
                 </CollectionView>
 
             </RefreshView>


### PR DESCRIPTION
[STRY0028946 - \[Windows\] Caseload list items expand but don't shrink when resized](https://bcsocialsector.service-now.com/rm_story.do?sys_id=9c69a2af87b4ce943b837446dabb35a6&sysparm_view=&sysparm_time=1711484618337)