### PR TITLE
Windows logout workaround

### DIFF
--- a/visitz/Oidc/OidcSession.cs
+++ b/visitz/Oidc/OidcSession.cs
@@ -103,6 +103,17 @@ namespace Oidc
             return logoutSuccess;
         }
 
+		public static async Task LocalLogoutAsync()
+		{
+#if DEBUG
+			ConsoleTrace.TraceMethod(typeof(OidcSession), $"Local logout initiated");
+#endif
+			await InvalidateSessionAsync();
+
+			var info = await OidcSessionInfo.GetAsync();
+			SessionChanged?.Invoke(info, new LogoutChangedEventArgs() { Success = true });
+		}
+
         public static async Task<OidcSessionInfo> GetInfoAsync()
         {
             return await OidcSessionInfo.GetAsync();

--- a/visitz/Visitz/Navigator.cs
+++ b/visitz/Visitz/Navigator.cs
@@ -1,4 +1,4 @@
-﻿using Visitz.Pages;
+using Visitz.Pages;
 using VisitzModel;
 
 namespace Visitz;
@@ -45,4 +45,10 @@ public class Navigator
         else
             await fromPage.Navigation.PushAsync(newPage, animated);
     }
+
+	public static async Task PopAllModalsAsync(bool animated)
+	{
+		while (Navigation.ModalStack.Count > 0)
+			await Navigation.PopModalAsync(animated);
+	}
 }

--- a/visitz/Visitz/Platforms/Windows/Visitz/Pages/WebViewPage.cs
+++ b/visitz/Visitz/Platforms/Windows/Visitz/Pages/WebViewPage.cs
@@ -15,7 +15,7 @@ public partial class WebViewPage
 
 	readonly Uri _baseRedirectUri = new(new AppSettings().Oidc.RedirectUri);
 
-	Action SessionAction { get; set; }
+	Func<Task> SessionTask { get; set; }
 
 	partial void Setup()
 	{
@@ -47,16 +47,24 @@ public partial class WebViewPage
 		var webView = sender as WebView;
 		var coreWebView = await GetCoreWebView(webView);
 
-		coreWebView.NavigationCompleted += CompleteRedirectNavigation;
 		coreWebView.NavigationStarting += (sender, args) =>
 		{
 			if (args.Uri.StartsWith(_baseRedirectUri.Scheme, StringComparison.InvariantCultureIgnoreCase))
 			{
-				SessionAction = async () => await PerformCustomSchemeRedirect(args.Uri);
+				SessionTask = async () => await PerformCustomSchemeRedirect(args.Uri);
 			}
 			else if (args.Uri.Contains(_logoutResponse, StringComparison.InvariantCultureIgnoreCase))
 			{
-				SessionAction = async () => await ForceLogout(sender);
+				SessionTask = async () => await ForceLogout(sender);
+			}
+		};
+
+		coreWebView.NavigationCompleted += async (sender, args) =>
+		{
+			if (SessionTask != null)
+			{
+				await SessionTask();
+				await Navigator.Navigation.PopModalAsync();
 			}
 		};
 
@@ -72,16 +80,7 @@ public partial class WebViewPage
 		webView.Source = ViewModel.AuthUri;
 	}
 
-	public void CompleteRedirectNavigation(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
-	{
-		if (SessionAction != null && args.HttpStatusCode >= ((int)HttpStatusCode.InternalServerError))
-		{
-			SessionAction();
-			SessionAction = null;
-		}
-	}
-
-	private static async Task PerformCustomSchemeRedirect(string uri)
+	private static Task PerformCustomSchemeRedirect(string uri)
 	{
 		Process.Start(new ProcessStartInfo
 		{
@@ -89,7 +88,7 @@ public partial class WebViewPage
 			UseShellExecute = true,
 		});
 
-		await Navigator.Navigation.PopModalAsync();
+		return Task.CompletedTask;
 	}
 
 	// A workaround implementation to forcibly logout the user on Windows.
@@ -102,7 +101,6 @@ public partial class WebViewPage
 
 		await CancelTokenSource?.CancelAsync();
 		await OidcSession.LocalLogoutAsync();
-		await Navigator.Navigation.PopModalAsync();
 	}
 
 	private void CloseButton_Closing(object sender, ClosingEventArgs e)

--- a/visitz/Visitz/Platforms/Windows/Visitz/Pages/WebViewPage.cs
+++ b/visitz/Visitz/Platforms/Windows/Visitz/Pages/WebViewPage.cs
@@ -1,6 +1,8 @@
 using Microsoft.UI.Xaml.Controls;
 using Microsoft.Web.WebView2.Core;
+using Oidc;
 using System.Diagnostics;
+using System.Net;
 using Visitz.Controls;
 using Visitz.Resources.Localization;
 using Visitz.Settings;
@@ -9,9 +11,11 @@ namespace Visitz.Pages;
 
 public partial class WebViewPage
 {
+	const string _logoutResponse = "/logout_response";
+
 	readonly Uri _baseRedirectUri = new(new AppSettings().Oidc.RedirectUri);
 
-	string _redirectUri;
+	Action SessionAction { get; set; }
 
 	partial void Setup()
 	{
@@ -43,12 +47,16 @@ public partial class WebViewPage
 		var webView = sender as WebView;
 		var coreWebView = await GetCoreWebView(webView);
 
+		coreWebView.NavigationCompleted += CompleteRedirectNavigation;
 		coreWebView.NavigationStarting += (sender, args) =>
 		{
-			if (args.Uri.StartsWith(_baseRedirectUri.Scheme))
+			if (args.Uri.StartsWith(_baseRedirectUri.Scheme, StringComparison.InvariantCultureIgnoreCase))
 			{
-				_redirectUri = args.Uri;
-				sender.NavigationCompleted += CompleteRedirectNavigation;
+				SessionAction = async () => await PerformCustomSchemeRedirect(args.Uri);
+			}
+			else if (args.Uri.Contains(_logoutResponse, StringComparison.InvariantCultureIgnoreCase))
+			{
+				SessionAction = async () => await ForceLogout(sender);
 			}
 		};
 
@@ -64,17 +72,37 @@ public partial class WebViewPage
 		webView.Source = ViewModel.AuthUri;
 	}
 
-	public void CompleteRedirectNavigation(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs _args)
+	public void CompleteRedirectNavigation(CoreWebView2 sender, CoreWebView2NavigationCompletedEventArgs args)
+	{
+		if (SessionAction != null && args.HttpStatusCode >= ((int)HttpStatusCode.InternalServerError))
+		{
+			SessionAction();
+			SessionAction = null;
+		}
+	}
+
+	private static async Task PerformCustomSchemeRedirect(string uri)
 	{
 		Process.Start(new ProcessStartInfo
 		{
-			FileName = _redirectUri,
+			FileName = uri,
 			UseShellExecute = true,
 		});
 
-		_ = Navigator.Navigation.PopModalAsync();
+		await Navigator.Navigation.PopModalAsync();
+	}
 
-		sender.NavigationCompleted -= CompleteRedirectNavigation;
+	// A workaround implementation to forcibly logout the user on Windows.
+	// This, along with the rest of the Windows OIDC workarounds, may not
+	// be needed once https://github.com/microsoft/WindowsAppSDK/issues/441
+	// is fixed.
+	private async Task ForceLogout(CoreWebView2 coreWebView)
+	{
+		coreWebView.CookieManager.DeleteAllCookies();
+
+		await CancelTokenSource?.CancelAsync();
+		await OidcSession.LocalLogoutAsync();
+		await Navigator.Navigation.PopModalAsync();
 	}
 
 	private void CloseButton_Closing(object sender, ClosingEventArgs e)

--- a/visitz/Visitz/ViewModels/SessionViewModel.cs
+++ b/visitz/Visitz/ViewModels/SessionViewModel.cs
@@ -283,7 +283,7 @@ public partial class SessionViewModel
     private bool ShouldReopen()
     {
 #if IOS
-        return PresentationStyle == DialogStyle;
+        return true;
 #else
         return false;
 #endif

--- a/visitz/Visitz/ViewModels/SessionViewModel.cs
+++ b/visitz/Visitz/ViewModels/SessionViewModel.cs
@@ -68,7 +68,7 @@ public partial class SessionViewModel : VisitzViewModel
         SessionInfo = sender as OidcSessionInfo;
         await ApplyLayout();
 
-		if (e is LogoutChangedEventArgs args && args.Success && ShouldReopen())
+		if (e is LogoutChangedEventArgs && ShouldReopen())
 			_ = ReopenSessionPage();
 
 	}

--- a/visitz/Visitz/ViewModels/SessionViewModel.cs
+++ b/visitz/Visitz/ViewModels/SessionViewModel.cs
@@ -2,6 +2,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
 using Oidc;
+using Oidc.Events;
 using Visitz.Extensions;
 using Visitz.FontIcons;
 using Visitz.Pages;
@@ -50,23 +51,27 @@ public partial class SessionViewModel : VisitzViewModel
         SessionInfo = await OidcSessionInfo.GetAsync();
         await ApplyLayout();
 
-        OidcSession.SessionChanged += VisitzSession_SessionChanged;
+        OidcSession.SessionChanged += OidcSession_SessionChanged;
 
         BackgroundImageUri = await BcGovAlbum.GetFeaturedPictureUri();
     }
 
     public override void Destroy()
     {
-        OidcSession.SessionChanged -= VisitzSession_SessionChanged;
+        OidcSession.SessionChanged -= OidcSession_SessionChanged;
 
         base.Destroy();
     }
 
-    private async void VisitzSession_SessionChanged(object sender, EventArgs e)
+    private async void OidcSession_SessionChanged(object sender, SessionChangedEventArgs e)
     {
         SessionInfo = sender as OidcSessionInfo;
         await ApplyLayout();
-    }
+
+		if (e is LogoutChangedEventArgs args && args.Success && ShouldReopen())
+			_ = ReopenSessionPage();
+
+	}
 
     private async Task ApplyLayout()
     {
@@ -112,7 +117,7 @@ public partial class SessionViewModel
 
             if (SessionInfo.HasBasicAccessRole())
             {
-                await Navigator.Navigation.PopModalAsync();
+				await Navigator.PopAllModalsAsync(true);
                 WeakReferenceMessenger.Default.Send(GetAllDataForOfflineService.MakeStartMessage());
             }
         }
@@ -188,12 +193,12 @@ public partial class SessionViewModel
     }
 
     [RelayCommand]
-	public void TryLogout()
+	public static void TryLogout()
     {
 		_ = PromptAndLogoutAsync();
     }
 
-	private async Task PromptAndLogoutAsync()
+	private static async Task PromptAndLogoutAsync()
 	{
         if (await PromptLogout())
             await DoLogoutAsync();
@@ -208,19 +213,16 @@ public partial class SessionViewModel
             LocalizedStrings.Cancel);
     }
 
-    private async Task DoLogoutAsync()
+    private static async Task DoLogoutAsync()
     {
-        bool reopen = ShouldReopen();
-
         await OidcSession.LogoutAsync();
-        await (await VisitzRealms.GetIcmDataAsync()).ClearAllData();
-
-        if (reopen)
-        {
-            await Navigator.Navigation.PopModalAsync();
-            await Navigator.GoToPage<SessionPage>(modal: true);
-        }
     }
+
+	private static async Task ReopenSessionPage(bool modal = true)
+	{
+		await Navigator.PopAllModalsAsync(true);
+		await Navigator.GoToPage<SessionPage>(modal: modal);
+	}
 
     [RelayCommand]
     private static void RequestAccess()

--- a/visitz/Visitz/VisitzApp.xaml.cs
+++ b/visitz/Visitz/VisitzApp.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Oidc;
+using Oidc;
+using Oidc.Events;
 using Visitz.Pages;
 using Visitz.Services;
 using Visitz.Storage;
@@ -24,6 +25,8 @@ public partial class VisitzApp : Application
 
 		Oidc.WinWorkaround.WebAuthenticator.PromptAuthentication += WebAuthenticator_PromptForCredentials;
 #endif
+
+		OidcSession.SessionChanged += OidcSession_SessionChanged;
 
         InitializeComponent();
 
@@ -126,4 +129,15 @@ public partial class VisitzApp : Application
     {
         await DebugOptionsPage.TryOpen();
     }
+
+	private void OidcSession_SessionChanged(object sender, SessionChangedEventArgs e)
+	{
+		if (e is LogoutChangedEventArgs args && args.Success)
+			_ = ClearIcmData();
+	}
+
+	private static async Task ClearIcmData()
+	{
+		await (await VisitzRealms.GetIcmDataAsync()).ClearAllData();
+	}
 }


### PR DESCRIPTION
[STRY0028829 - Fix Windows logout flow](https://bcsocialsector.service-now.com/rm_story.do?sys_id=05eaed0a877486543b837446dabb35e2&sysparm_view=&sysparm_time=1713369477947)

Part of the work on https://github.com/BC-Gov-Social-Sector/mcfd-mobility/issues/68.

This logout workaround/implementation *mostly* works. The main issue is the identity server mangling the custom **state** parameter when initiating logout. So the session would be logged out in some IDPs, but would fail on others throughout the federated chain, hanging the logout flow in the app.

The main UX workaround is to wait for a "/logout_response" call and a >= HTTP 500 error, then forcibly discard the session locally and clear WebView2 cookies.