### PR TITLE
Add handler to workaround date parsing issue

### DIFF
--- a/visitz/Oidc/AppendAcceptLanguageHandler.cs
+++ b/visitz/Oidc/AppendAcceptLanguageHandler.cs
@@ -1,0 +1,20 @@
+﻿using System.Net.Http.Headers;
+
+namespace Oidc
+{
+    /// <summary>
+    /// Forces a workaround Accept-Language header. Some environments don't accept the automatic header provided by iOS
+    /// (a mix of en-CA and en-US in our case) and will fail when parsing the expected DateTime structure 
+    /// (MMM YYYY instead of MMM. YYYY).
+    /// </summary>
+	public class AppendAcceptLanguageHandler : DelegatingHandler
+    {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            request.Headers.AcceptLanguage.Clear();
+            request.Headers.AcceptLanguage.Add(new StringWithQualityHeaderValue("en-US"));
+            return await base.SendAsync(request, cancellationToken);
+        }
+    }
+}
+

--- a/visitz/Visitz/VisitzConfig/VisitzApiConfig.cs
+++ b/visitz/Visitz/VisitzConfig/VisitzApiConfig.cs
@@ -11,8 +11,10 @@ namespace Visitz.VisitzConfig
         public static MauiAppBuilder ConfigureVisitzApi(this MauiAppBuilder builder)
         {
             builder.Services.AddSingleton<AppendTokenHandler>();
+            builder.Services.AddSingleton<AppendAcceptLanguageHandler>();
 
             builder.Services.AddHttpClient(HttpClientName).AddHttpMessageHandler<AppendTokenHandler>();
+            builder.Services.AddHttpClient(HttpClientName).AddHttpMessageHandler<AppendAcceptLanguageHandler>();
 
             builder.Services.AddSingleton(sp => 
                 sp.GetRequiredService<IHttpClientFactory>().CreateClient(HttpClientName));


### PR DESCRIPTION
[STRY0029281 - Test SIT1 API endpoints](https://bcsocialsector.service-now.com/rm_story.do?sys_id=8730cf4a87814a103b837446dabb35e8&sysparm_view=&sysparm_time=1714076445953)