### PR TITLE
Sort family members

### DIFF
--- a/visitz/Visitz/ViewModels/Entity/EntityContactsViewModel.cs
+++ b/visitz/Visitz/ViewModels/Entity/EntityContactsViewModel.cs
@@ -1,5 +1,6 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.ComponentModel;
 using VisitzModel.Models;
+using VisitzModel.Sorting;
 
 namespace Visitz.ViewModels.Entity;
 
@@ -15,6 +16,6 @@ public partial class EntityContactsViewModel : VisitzViewModel, ICaseloadItemHol
     {
         base.Create();
 
-        Contacts = CaseloadItem.FamilyMembers;
+        Contacts = CaseloadItem.FamilyMembers.Order(new FamilyMemberComparer());
     }
 }

--- a/visitz/VisitzModel/Extensions/StringExtensions.cs
+++ b/visitz/VisitzModel/Extensions/StringExtensions.cs
@@ -1,4 +1,4 @@
-﻿namespace VisitzModel.Extensions;
+namespace VisitzModel.Extensions;
 
 public static class StringExtensions
 {
@@ -32,4 +32,12 @@ public static class StringExtensions
     {
         return text != null && text.Trim().StartsWith("Y", StringComparison.CurrentCultureIgnoreCase);
     }
+
+	public static bool? ParseEmptyWordTruthiness(this string text)
+	{
+		if (text == null || text.Trim().Length == 0)
+			return null;
+		else
+			return ParseWordTruthiness(text);
+	}
 }

--- a/visitz/VisitzModel/Models/FamilyMember.cs
+++ b/visitz/VisitzModel/Models/FamilyMember.cs
@@ -7,7 +7,12 @@ namespace VisitzModel.Models
 {
     public partial class FamilyMember : IEmbeddedObject
     {
-        public string ContactId { get; set; }
+		public static readonly int KeyPlayerSortPosition = 0;
+		public static readonly int ParentCaregiverSortPosition = 1;
+		public static readonly int SubjectChildSortPosition = 2;
+		public static readonly int OtherSortPosition = int.MaxValue;
+
+		public string ContactId { get; set; }
         public string KeyPlayer { get; set; }
         public string LastName { get; set; }
         public string FirstName { get; set; }
@@ -57,13 +62,13 @@ namespace VisitzModel.Models
 			get
 			{
 				if (IsKeyPlayer)
-					return 0;
+					return KeyPlayerSortPosition;
 				else if (ParentCaregiver ?? false)
-					return 1;
+					return ParentCaregiverSortPosition;
 				else if (SubjectChild ?? false)
-					return 2;
+					return SubjectChildSortPosition;
 				else
-					return int.MaxValue;
+					return OtherSortPosition;
 			}
 		}
 

--- a/visitz/VisitzModel/Models/FamilyMember.cs
+++ b/visitz/VisitzModel/Models/FamilyMember.cs
@@ -28,6 +28,9 @@ namespace VisitzModel.Models
         public string ContactPostalCode { get; set; }
         public string ContactProvinceState { get; set; }
         public string ContactCountry { get; set; }
+		public bool? SubjectFlag { get; set; }
+		public bool? ParentCaregiver { get; set; }
+		public bool? SubjectChild { get; set; }
 
         public string FullDisplayName => string.Join(" ",
             FirstName, MiddleName, LastName);
@@ -83,6 +86,9 @@ namespace VisitzModel.Models
                 ContactPostalCode = familyMember.ContactPostalCode,
                 ContactProvinceState = familyMember.ContactProvinceState,
                 ContactCountry = familyMember.ContactCountry,
+				SubjectFlag = familyMember.SubjectFlag.ParseEmptyWordTruthiness(),
+				ParentCaregiver = familyMember.ParentCaregiver.ParseEmptyWordTruthiness(),
+				SubjectChild = familyMember.SubjectChild.ParseEmptyWordTruthiness(),
             };
         }
 

--- a/visitz/VisitzModel/Models/FamilyMember.cs
+++ b/visitz/VisitzModel/Models/FamilyMember.cs
@@ -52,6 +52,21 @@ namespace VisitzModel.Models
             .TrimEnd([',', ' ', '-'])
             .TrimEnd([',', ' ', '-']);
 
+		public int SortPositionAsc
+		{
+			get
+			{
+				if (IsKeyPlayer)
+					return 0;
+				else if (ParentCaregiver ?? false)
+					return 1;
+				else if (SubjectChild ?? false)
+					return 2;
+				else
+					return int.MaxValue;
+			}
+		}
+
 #pragma warning disable SS003 // The operands of a divisive expression are both integers and result in an implicit rounding.
 		public int? Age => DateTime.TryParse(DateOfBirth, out DateTime dateOfBirth)
 					? (DateTimeExtensions.LocalNow - dateOfBirth).Days / 365 // Integer division is intentional

--- a/visitz/VisitzModel/Sorting/FamilyMemberComparer.cs
+++ b/visitz/VisitzModel/Sorting/FamilyMemberComparer.cs
@@ -1,0 +1,22 @@
+using System.Runtime.CompilerServices;
+using VisitzModel.Models;
+
+namespace VisitzModel.Sorting;
+
+public class FamilyMemberComparer : IComparer<FamilyMember>
+{
+	public int Compare(FamilyMember x, FamilyMember y)
+	{
+		if (x == null || y == null)
+			return 0;
+		if (x.SortPositionAsc == y.SortPositionAsc)
+			return CompareAgeDesc(y.Age, x.Age);
+		else
+			return x.SortPositionAsc.CompareTo(y.SortPositionAsc);
+	}
+
+	private static int CompareAgeDesc(int? yAge, int? xAge)
+	{
+		return (yAge ?? int.MinValue).CompareTo(xAge ?? int.MinValue);
+	}
+}

--- a/visitz/VisitzModel/Storage/IcmData.cs
+++ b/visitz/VisitzModel/Storage/IcmData.cs
@@ -1,4 +1,4 @@
-﻿using Realms;
+using Realms;
 using Realms.Schema;
 using VisitzModel.Models;
 using VisitzModel.Storage.Migrations;
@@ -8,7 +8,7 @@ namespace VisitzModel.Storage;
 public class IcmData(byte[] encryptionKey) : VisitzRealmBase(Name, CurrentVersion, encryptionKey)
 {
     public static readonly string Name = "icmDataCopies.realm";
-    public static readonly ulong CurrentVersion = Version2_0;
+    public static readonly ulong CurrentVersion = Version2_1;
 
     protected override RealmSchema MakeRealmSchema()
     {

--- a/visitz/VisitzModel/Storage/Migrations/IcmDataMigrations.cs
+++ b/visitz/VisitzModel/Storage/Migrations/IcmDataMigrations.cs
@@ -1,4 +1,5 @@
-﻿using Realms;
+using Realms;
+using System.Reflection;
 using VisitzModel.Models;
 
 namespace VisitzModel.Storage.Migrations;
@@ -7,10 +8,47 @@ public static class IcmDataMigrations
 {
     public static void MigrateRealm(Migration migration, ulong oldSchemaVersion)
     {
-        //TODO: Migrate CaseloadItems
-        //TODO: Migrate FamilyMembers
+        MigrateCaseloadItems(migration, oldSchemaVersion);
         MigrateNoteItems(migration, oldSchemaVersion);
     }
+
+	private static void MigrateCaseloadItems(Migration migration, ulong oldSchemaVersion)
+	{
+		const string CaseloadItemName = "CaseloadItem";
+
+		var oldItems = migration.OldRealm.DynamicApi.All(CaseloadItemName);
+		var newItems = migration.NewRealm.DynamicApi.All(CaseloadItemName);
+
+		for (int i = 0; i < newItems.Count(); i++)
+			//TODO: Migrate CaseloadItems
+			MigrateItemFamilyMembers(oldSchemaVersion, oldItems.ElementAt(i), newItems.ElementAt(i));
+	}
+
+	private static void MigrateItemFamilyMembers(ulong oldSchemaVersion, IRealmObject _, IRealmObject newItem)
+	{
+		if (oldSchemaVersion < VisitzRealmBase.Version2_1)
+		{
+			const string SubjectFlag = "SubjectFlag";
+			const string ParentCaregiver = "ParentCaregiver";
+			const string SubjectChild = "SubjectChild";
+			
+			var newFamily = newItem.DynamicApi.GetList<IRealmObjectBase>("FamilyMembers");
+
+			foreach (var member in newFamily)
+			{
+				var type = member.GetType();
+
+				if (type.GetProperty(SubjectFlag) is PropertyInfo subjectFlag)
+					subjectFlag.SetValue(member, null, null);
+
+				if (type.GetProperty(ParentCaregiver) is PropertyInfo parentCaregiver)
+					parentCaregiver.SetValue(member, null, null);
+
+				if (type.GetProperty(SubjectChild) is PropertyInfo subjectChild)
+					subjectChild.SetValue(member, null, null);
+			}
+		}
+	}
 
     private static void MigrateNoteItems(Migration migration, ulong oldSchemaVersion)
     {

--- a/visitz/VisitzModel/Storage/VisitzRealmBase.cs
+++ b/visitz/VisitzModel/Storage/VisitzRealmBase.cs
@@ -1,4 +1,4 @@
-﻿using Realms;
+using Realms;
 using Realms.Schema;
 
 #if WINDOWS
@@ -10,8 +10,9 @@ namespace VisitzModel.Storage;
 public abstract class VisitzRealmBase
 {
     public static readonly ulong Version2_0 = 1;
+	public static readonly ulong Version2_1 = 2;
 
-    public string RealmName { get; private set; }
+	public string RealmName { get; private set; }
 
     public ulong Version { get; private set; }
 

--- a/visitz/VisitzModelTest/Extensions/StringExtensionsTests.cs
+++ b/visitz/VisitzModelTest/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,25 @@
+using VisitzModel.Extensions;
+
+namespace VisitzModelTest.Extensions;
+
+public class StringExtensionsTests
+{
+	[Theory]
+	[InlineData("", null)]
+	[InlineData(" ", null)]
+	[InlineData("\t", null)]
+	[InlineData("Y", true)]
+	[InlineData("Yes", true)]
+	[InlineData("Yeah", true)]
+	[InlineData("Yep", true)]
+	[InlineData("N", false)]
+	[InlineData("No", false)]
+	[InlineData("Nope", false)]
+	[InlineData("Negative", false)]
+	public void ParseEmptyWordTruthiness_Valid(string input, bool? expected)
+	{
+		bool? emptyWordTruthiness = input.ParseEmptyWordTruthiness();
+
+		Assert.Equal(expected, emptyWordTruthiness);
+	}
+}

--- a/visitz/VisitzModelTest/Models/FamilyMemberTests.cs
+++ b/visitz/VisitzModelTest/Models/FamilyMemberTests.cs
@@ -1,4 +1,5 @@
 using VisitzModel.Models;
+using VisitzModel.Sorting;
 
 namespace VisitzModelTest.Models;
 
@@ -39,5 +40,141 @@ public class FamilyMemberTests
 		};
 
 		Assert.Equal(expectedAge, member.Age);
+	}
+
+	const string Mother = "Mother";
+	const string Father = "Father";
+	const string Uncle = "Uncle";
+	const string Cousin = "Cousin";
+	const string OlderAge = "2019-01-01 06:30:31";
+	const string YoungerAge = "2021-01-01 06:30:31";
+	const string YoungestAge = "2023-01-01 06:30:31";
+	const string NoAge = "";
+
+	const int ExpectedYoungerAgePosition = 0;
+	const int ExpectedMotherPosition = 1;
+	const int ExpectedFatherPosition = 2;
+	const int ExpectedOlderAgePosition = 3;
+	const int ExpectedYoungestAgePosition = 4;
+	const int ExpectedUnclePosition = 5;
+	const int ExpectedCousinPosition = 6;
+	const int ExpectedNoAgePosition = 7;
+
+	private static List<FamilyMember> MakeFamilyList()
+	{
+		return
+		[
+			new()
+			{
+				SubjectChild = true,
+				DateOfBirth = YoungestAge,
+			},
+			new()
+			{
+				SubjectChild = true,
+				DateOfBirth = OlderAge,
+			},
+			new()
+			{
+				KeyPlayer = "Y",
+				SubjectChild = true,
+				DateOfBirth = YoungerAge,
+			},
+			new()
+			{
+				Relationship = Mother,
+				ParentCaregiver = true,
+				DateOfBirth = OlderAge,
+			},
+			new()
+			{
+				DateOfBirth = NoAge,
+			},
+			new()
+			{
+				Relationship = Father,
+				ParentCaregiver = true,
+				DateOfBirth = YoungerAge,
+			},
+			new()
+			{
+				Relationship = Uncle,
+				DateOfBirth = OlderAge,
+			},
+			new()
+			{
+				Relationship = Cousin,
+				DateOfBirth = YoungerAge,
+			}
+		];
+	}
+
+	private static IOrderedEnumerable<FamilyMember> MakeOrderedFamilyEnumerable()
+	{
+		return MakeFamilyList().Order(new FamilyMemberComparer());
+	}
+
+	[Fact]
+	public void KeyPlayerSortOrderIsCorrect()
+	{
+		var family = MakeOrderedFamilyEnumerable();
+
+		Assert.True(family.ElementAt(ExpectedYoungerAgePosition).IsKeyPlayer);
+	}
+
+	[Fact]
+	public void MotherSortOrderIsCorrect()
+	{
+		var family = MakeOrderedFamilyEnumerable();
+
+		Assert.Equal(Mother, family.ElementAt(ExpectedMotherPosition).Relationship);
+	}
+
+	[Fact]
+	public void FatherSortOrderIsCorrect()
+	{
+		var family = MakeOrderedFamilyEnumerable();
+
+		Assert.Equal(Father, family.ElementAt(ExpectedFatherPosition).Relationship);
+	}
+
+	[Fact]
+	public void UncleSortOrderIsCorrect()
+	{
+		var family = MakeOrderedFamilyEnumerable();
+
+		Assert.Equal(Uncle, family.ElementAt(ExpectedUnclePosition).Relationship);
+	}
+
+	[Fact]
+	public void CousinSortOrderIsCorrect()
+	{
+		var family = MakeOrderedFamilyEnumerable();
+
+		Assert.Equal(Cousin, family.ElementAt(ExpectedCousinPosition).Relationship);
+	}
+
+	[Fact]
+	public void ChildOlderSortOrderIsCorrect()
+	{
+		var family = MakeOrderedFamilyEnumerable();
+
+		Assert.Equal(OlderAge, family.ElementAt(ExpectedOlderAgePosition).DateOfBirth);
+	}
+
+	[Fact]
+	public void ChildYoungestSortOrderIsCorrect()
+	{
+		var family = MakeOrderedFamilyEnumerable();
+
+		Assert.Equal(YoungestAge, family.ElementAt(ExpectedYoungestAgePosition).DateOfBirth);
+	}
+
+	[Fact]
+	public void NoAgeSortOrderIsCorrect()
+	{
+		var family = MakeOrderedFamilyEnumerable();
+
+		Assert.Empty(family.ElementAt(ExpectedNoAgePosition).DateOfBirth);
 	}
 }


### PR DESCRIPTION
[STRY0027474 - Sort family members list](https://bcsocialsector.service-now.com/rm_story.do?sys_id=0ea3f29a1b808ad05b04ed72b24bcb06&sysparm_view=&sysparm_time=1714423420736)

Implemented a custom sort order for contacts when viewed in the "Family members" section.

A Realm migration was required—needed to interact with a few fields that hadn't previously been implemented in the Realm model.