### PR TITLE
Cascade delete notes

### DIFF
--- a/visitz/Visitz/Services/GetCaseloadService.cs
+++ b/visitz/Visitz/Services/GetCaseloadService.cs
@@ -43,16 +43,7 @@ namespace Visitz.Services
             caseloadContent = FilterNonCasesAndIncidents(caseloadContent);
 
             using var realm = await VisitzRealms.GetIcmDataRealmAsync();
-            var currentCaseload = realm.All<CaseloadItem>();
-            var deletedCaseload = currentCaseload.ExceptBy(caseloadContent.Select(CaseloadSelector), CaseloadSelector);
-
-            await realm.WriteAsync(() =>
-            {
-                foreach (var deletedCaseloadItem in deletedCaseload)
-                    realm.Remove(deletedCaseloadItem);
-
-                realm.Add(caseloadContent, update: true);
-            });
+            await CaseloadItem.ReplaceCaseloadWithAsync(realm, caseloadContent);
 
             ResultCode = Result.Successful;
 			LastUpdated.Set(GetId(), DateTimeExtensions.LocalNow);
@@ -77,7 +68,5 @@ namespace Visitz.Services
 				return type == EntityType.Case || type == EntityType.Incident;
 			});
         }
-
-        static string CaseloadSelector(CaseloadItem caseloadItem) => caseloadItem.CaseIncidentNumber;
     }
 }

--- a/visitz/VisitzModel/Models/CaseloadItem.cs
+++ b/visitz/VisitzModel/Models/CaseloadItem.cs
@@ -154,5 +154,21 @@ namespace VisitzModel.Models
                 .All<CaseloadItem>()
                 .Filter($"TRUEPREDICATE DISTINCT({subtype}) SORT({subtype} {sortDirection})");
         }
-    }
+
+		public static async Task ReplaceCaseloadWithAsync(Realm realm, IEnumerable<CaseloadItem> newCaseloadItems)
+		{
+			var currentCaseload = realm.All<CaseloadItem>();
+			var itemsToDelete = currentCaseload.ExceptBy(newCaseloadItems.Select(CaseloadSelector), CaseloadSelector);
+
+			await realm.WriteAsync(() =>
+			{
+				foreach (var itemToDelete in itemsToDelete)
+					realm.Remove(itemToDelete);
+
+				realm.Add(newCaseloadItems, update: true);
+			});
+		}
+
+		static string CaseloadSelector(CaseloadItem caseloadItem) => caseloadItem.CaseIncidentNumber;
+	}
 }

--- a/visitz/VisitzModel/Models/CaseloadItem.cs
+++ b/visitz/VisitzModel/Models/CaseloadItem.cs
@@ -155,6 +155,13 @@ namespace VisitzModel.Models
                 .Filter($"TRUEPREDICATE DISTINCT({subtype}) SORT({subtype} {sortDirection})");
         }
 
+		/// <summary>
+		/// Adds new CaseloadItems to the Realm and cascade-deletes any pre-existing CaseloadItems not found in the incoming list.
+		/// The cascade deletion only extends to objects within this Realm—it does not affect any drafts the user may have.
+		/// </summary>
+		/// <param name="realm"></param>
+		/// <param name="newCaseloadItems"></param>
+		/// <returns></returns>
 		public static async Task ReplaceCaseloadWithAsync(Realm realm, IEnumerable<CaseloadItem> newCaseloadItems)
 		{
 			var currentCaseload = realm.All<CaseloadItem>();
@@ -163,10 +170,18 @@ namespace VisitzModel.Models
 			await realm.WriteAsync(() =>
 			{
 				foreach (var itemToDelete in itemsToDelete)
-					realm.Remove(itemToDelete);
+					CascadeDelete(realm, itemToDelete);
 
 				realm.Add(newCaseloadItems, update: true);
 			});
+		}
+
+		static void CascadeDelete(Realm realm, CaseloadItem itemToDelete)
+		{
+			foreach (var note in NoteItem.GetNotesByEntityId(realm, itemToDelete.CaseIncidentNumber))
+				realm.Remove(note);
+
+			realm.Remove(itemToDelete);
 		}
 
 		static string CaseloadSelector(CaseloadItem caseloadItem) => caseloadItem.CaseIncidentNumber;


### PR DESCRIPTION
[STRY0027411 - Cascade delete notes when their parent entity is deleted](https://bcsocialsector.service-now.com/rm_story.do?sys_id=26d3f8391b4c42d05b04ed72b24bcbf8&sysparm_view=&sysparm_time=1714432222751)