### PR TITLE
Offline indicator

### DIFF
--- a/visitz/Visitz/Pages/RootPage.xaml
+++ b/visitz/Visitz/Pages/RootPage.xaml
@@ -15,44 +15,57 @@
         <toolkit:StatusBarBehavior StatusBarStyle="LightContent" StatusBarColor="{StaticResource BuildBarBackgroundColor}" />
     </pages:VisitzPage.Behaviors>
 
-    <StackLayout Orientation="Vertical">
-        <StackLayout 
-            Orientation="Horizontal"
-            HorizontalOptions="FillAndExpand" 
-            VerticalOptions="FillAndExpand">
+	<AbsoluteLayout x:Name="RootAbsoluteLayout">
+		<StackLayout
+			AbsoluteLayout.LayoutFlags="All"
+			AbsoluteLayout.LayoutBounds="0,0,1,1"
+			Orientation="Vertical">
+			
+			<StackLayout 
+				Orientation="Horizontal"
+				HorizontalOptions="FillAndExpand" 
+				VerticalOptions="FillAndExpand">
 
-            <!-- 
-                For some reason it seems that the ContentView's implicit binding context changes, so we need to
-                specifically reference RootViewModel.
-            -->
-            <nav:VerticalNavRailView IsVisible="{Binding IsLandscape, 
-                Source={RelativeSource AncestorType={x:Type viewmodels:RootViewModel}}}" />
+				<!-- 
+					For some reason it seems that the ContentView's implicit binding context changes, so we need to
+					specifically reference RootViewModel.
+				-->
+				<nav:VerticalNavRailView IsVisible="{Binding IsLandscape, 
+					Source={RelativeSource AncestorType={x:Type viewmodels:RootViewModel}}}" />
 
-            <BoxView 
-                IsVisible="{Binding IsLandscape}"
-                WidthRequest="2"
-                Color="{StaticResource BC_Gold}" />
+				<BoxView 
+					IsVisible="{Binding IsLandscape}"
+					WidthRequest="2"
+					Color="{StaticResource BC_Gold}" />
 
-            <StackLayout 
-                x:Name="ContentPane" 
-                Orientation="Horizontal"
-                HorizontalOptions="FillAndExpand" 
-                VerticalOptions="FillAndExpand" />
+				<StackLayout 
+					x:Name="ContentPane" 
+					Orientation="Horizontal"
+					HorizontalOptions="FillAndExpand" 
+					VerticalOptions="FillAndExpand" />
 
-        </StackLayout>
+			</StackLayout>
 
-        <BoxView 
-            IsVisible="{Binding IsPortrait}"
-            HeightRequest="2"
-            Color="{StaticResource BC_Gold}" />
+			<BoxView 
+				IsVisible="{Binding IsPortrait}"
+				HeightRequest="2"
+				Color="{StaticResource BC_Gold}" />
 
-        <!-- 
-            For some reason it seems that the ContentView's implicit binding context changes, so we need to
-            specifically reference RootViewModel.
-        -->
-        <nav:HorizontalNavRailView IsVisible="{Binding IsPortrait, 
-            Source={RelativeSource AncestorType={x:Type viewmodels:RootViewModel}}}" />
+			<!-- 
+				For some reason it seems that the ContentView's implicit binding context changes, so we need to
+				specifically reference RootViewModel.
+			-->
+			<nav:HorizontalNavRailView IsVisible="{Binding IsPortrait, 
+				Source={RelativeSource AncestorType={x:Type viewmodels:RootViewModel}}}" />
 
-    </StackLayout>
+		</StackLayout>
+
+		<ContentView
+			x:Name="SnackbarContainer"
+			AbsoluteLayout.LayoutFlags="PositionProportional"
+			AbsoluteLayout.LayoutBounds="0.5,1"
+			Margin="48"
+			IsVisible="False" />
+	</AbsoluteLayout>
     
 </pages:VisitzPage>

--- a/visitz/Visitz/Pages/RootPage.xaml.cs
+++ b/visitz/Visitz/Pages/RootPage.xaml.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Mvvm.Messaging;
+using Visitz.Animations;
 using Visitz.ViewModels;
 using Visitz.Views;
 using VisitzModel;
@@ -57,14 +58,23 @@ public partial class RootPage : VisitzPage, ISnackbarPresenter
 
 		Snackbar = snackbar;
 		SnackbarContainer.Content = Snackbar;
-
 		SnackbarContainer.IsVisible = Snackbar != null;
+
 		if (Snackbar != null)
+		{
 			Snackbar.ShouldClose += Snackbar_ShouldClose;
+			_ = new VisibilityAnimation(showView: true, 150).Animate(Snackbar);
+		}
 	}
 
 	public void Snackbar_ShouldClose(object sender, EventArgs e)
 	{
+		_ = AnimateCloseSnackbar();
+	}
+
+	private async Task AnimateCloseSnackbar()
+	{
+		await new VisibilityAnimation(showView: false, 150).Animate(Snackbar);
 		SetSnackbar(null);
 	}
 }

--- a/visitz/Visitz/Pages/RootPage.xaml.cs
+++ b/visitz/Visitz/Pages/RootPage.xaml.cs
@@ -1,12 +1,16 @@
 using CommunityToolkit.Mvvm.Messaging;
 using Visitz.ViewModels;
+using Visitz.Views;
+using VisitzModel;
 using VisitzModel.Messaging;
 using VisitzModel.Models;
 
 namespace Visitz.Pages;
 
-public partial class RootPage : VisitzPage
+public partial class RootPage : VisitzPage, ISnackbarPresenter
 {
+	VisitzSnackbar Snackbar { get; set; }
+
 	public RootPage() : base(ServiceProvider.GetService<RootViewModel>())
 	{
 		InitializeComponent();
@@ -44,5 +48,23 @@ public partial class RootPage : VisitzPage
 
         ContentPane.Clear();
         ContentPane.Add(view);
+	}
+
+	public void SetSnackbar(VisitzSnackbar snackbar)
+	{
+		if (Snackbar != null)
+			Snackbar.ShouldClose -= Snackbar_ShouldClose;
+
+		Snackbar = snackbar;
+		SnackbarContainer.Content = Snackbar;
+
+		SnackbarContainer.IsVisible = Snackbar != null;
+		if (Snackbar != null)
+			Snackbar.ShouldClose += Snackbar_ShouldClose;
+	}
+
+	public void Snackbar_ShouldClose(object sender, EventArgs e)
+	{
+		SetSnackbar(null);
 	}
 }

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -277,6 +277,28 @@ namespace Visitz.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Device offline.
+        /// </summary>
+        public static string DeviceOffline {
+            get {
+                return ResourceManager.GetString("DeviceOffline", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Your device is not connected to the internet right now.
+        ///
+        ///Your caseload and any drafts you&apos;ve made are still available on this device and you can continue to work on them.
+        ///
+        ///When this device is online again you can refresh your caseload or publish any work to ICM..
+        /// </summary>
+        public static string DeviceOfflineDesc {
+            get {
+                return ResourceManager.GetString("DeviceOfflineDesc", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Discard.
         /// </summary>
         public static string Discard {
@@ -666,6 +688,15 @@ namespace Visitz.Resources.Localization {
         public static string MarkAllThatApply {
             get {
                 return ResourceManager.GetString("MarkAllThatApply", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to More info.
+        /// </summary>
+        public static string MoreInfo {
+            get {
+                return ResourceManager.GetString("MoreInfo", resourceCulture);
             }
         }
         
@@ -1584,6 +1615,15 @@ namespace Visitz.Resources.Localization {
         public static string Type {
             get {
                 return ResourceManager.GetString("Type", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Unable to reach ICM (device offline).
+        /// </summary>
+        public static string UnableToReachIcmDeviceOffline {
+            get {
+                return ResourceManager.GetString("UnableToReachIcmDeviceOffline", resourceCulture);
             }
         }
         

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -769,6 +769,15 @@ namespace Visitz.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Offline.
+        /// </summary>
+        public static string Offline {
+            get {
+                return ResourceManager.GetString("Offline", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Ok.
         /// </summary>
         public static string Ok {

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -643,4 +643,7 @@ If that doesn't work, request access by emailing </value>
   <data name="ServiceOffice" xml:space="preserve">
     <value>Service office</value>
   </data>
+  <data name="Offline" xml:space="preserve">
+    <value>Offline</value>
+  </data>
 </root>

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -646,4 +646,20 @@ If that doesn't work, request access by emailing </value>
   <data name="Offline" xml:space="preserve">
     <value>Offline</value>
   </data>
+  <data name="DeviceOffline" xml:space="preserve">
+    <value>Device offline</value>
+  </data>
+  <data name="DeviceOfflineDesc" xml:space="preserve">
+    <value>Your device is not connected to the internet right now.
+
+Your caseload and any drafts you've made are still available on this device and you can continue to work on them.
+
+When this device is online again you can refresh your caseload or publish any work to ICM.</value>
+  </data>
+  <data name="MoreInfo" xml:space="preserve">
+    <value>More info</value>
+  </data>
+  <data name="UnableToReachIcmDeviceOffline" xml:space="preserve">
+    <value>Unable to reach ICM (device offline)</value>
+  </data>
 </root>

--- a/visitz/Visitz/Services/VisitzApiService.cs
+++ b/visitz/Visitz/Services/VisitzApiService.cs
@@ -14,6 +14,17 @@ namespace Visitz.Services
 
         protected override sealed async Task RunServiceAsync()
         {
+			if (Connectivity.Current.NetworkAccess != NetworkAccess.Internet)
+			{
+				SnackbarHandler.ShowTextWithDetails(
+					LocalizedStrings.UnableToReachIcmDeviceOffline,
+					LocalizedStrings.DeviceOffline,
+					LocalizedStrings.DeviceOfflineDesc);
+
+				ResultCode = Result.Cancelled;
+				return;
+			}
+
             try
             {
 				var cancelTokenSource = new CancellationTokenSource();

--- a/visitz/Visitz/SnackbarHandler.cs
+++ b/visitz/Visitz/SnackbarHandler.cs
@@ -1,0 +1,30 @@
+using Visitz.Resources.Localization;
+using Visitz.Views;
+
+namespace Visitz;
+
+internal class SnackbarHandler
+{
+	public static readonly int DefaultDurationSeconds = 5;
+
+	public static void ShowTextWithDetails(
+		string snackPrompt,
+		string messageTitle,
+		string fullMessage,
+		TimeSpan? duration = null)
+	{
+		if (Navigator.CurrentOpenPage is ISnackbarPresenter presenter)
+			presenter.SetSnackbar(new VisitzSnackbar()
+			{
+				Message = snackPrompt,
+				ActionText = LocalizedStrings.MoreInfo,
+				Action = async () => await ShowDialogMessage(messageTitle, fullMessage),
+				Duration = duration ?? TimeSpan.FromSeconds(DefaultDurationSeconds)
+			});
+	}
+
+	static async Task ShowDialogMessage(string title, string message)
+	{
+		await Navigator.CurrentOpenPage.DisplayAlert(title, message, LocalizedStrings.Ok);
+	}
+}

--- a/visitz/Visitz/SnackbarHandler.cs
+++ b/visitz/Visitz/SnackbarHandler.cs
@@ -5,7 +5,20 @@ namespace Visitz;
 
 internal class SnackbarHandler
 {
-	public static readonly int DefaultDurationSeconds = 5;
+	public static readonly int DefaultTextOnlyDurationSeconds = 3;
+	public static readonly int DefaultActionDurationSeconds = 5;
+
+	public static void ShowText(string snackPrompt, TimeSpan? duration = null)
+	{
+		if (Navigator.CurrentOpenPage is ISnackbarPresenter presenter)
+			presenter.SetSnackbar(new VisitzSnackbar()
+			{
+				Message = snackPrompt,
+				ActionText = null,
+				Action = null,
+				Duration = duration ?? TimeSpan.FromSeconds(DefaultTextOnlyDurationSeconds)
+			});
+	}
 
 	public static void ShowTextWithDetails(
 		string snackPrompt,
@@ -19,7 +32,7 @@ internal class SnackbarHandler
 				Message = snackPrompt,
 				ActionText = LocalizedStrings.MoreInfo,
 				Action = async () => await ShowDialogMessage(messageTitle, fullMessage),
-				Duration = duration ?? TimeSpan.FromSeconds(DefaultDurationSeconds)
+				Duration = duration ?? TimeSpan.FromSeconds(DefaultActionDurationSeconds)
 			});
 	}
 

--- a/visitz/Visitz/ViewModels/DataRefreshViewModel.cs
+++ b/visitz/Visitz/ViewModels/DataRefreshViewModel.cs
@@ -1,0 +1,51 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Messaging;
+using Visitz.Services;
+
+namespace Visitz.ViewModels;
+
+internal partial class DataRefreshViewModel : VisitzViewModel
+{
+	[ObservableProperty]
+	public bool superMessageVisible = false;
+
+	[ObservableProperty]
+	public string superMessage;
+
+	public override void Create()
+	{
+		base.Create();
+
+		SetConnectivityMessage(Connectivity.Current.NetworkAccess);
+		Connectivity.Current.ConnectivityChanged += Current_ConnectivityChanged;
+	}
+
+	public override void Destroy()
+	{
+		base.Destroy();
+
+		Connectivity.Current.ConnectivityChanged -= Current_ConnectivityChanged;
+	}
+
+	private void Current_ConnectivityChanged(object sender, ConnectivityChangedEventArgs e)
+	{
+		SetConnectivityMessage(e.NetworkAccess);
+	}
+
+	private void SetConnectivityMessage(NetworkAccess access)
+	{
+		SuperMessage = access == NetworkAccess.Internet ? "" : "Offline";
+	}
+
+	[RelayCommand]
+	public static void RefreshData()
+	{
+		WeakReferenceMessenger.Default.Send(GetAllDataForOfflineService.MakeStartMessage());
+	}
+
+	partial void OnSuperMessageChanged(string value)
+	{
+		SuperMessageVisible = !string.IsNullOrWhiteSpace(value);
+	}
+}

--- a/visitz/Visitz/ViewModels/DataRefreshViewModel.cs
+++ b/visitz/Visitz/ViewModels/DataRefreshViewModel.cs
@@ -14,6 +14,9 @@ internal partial class DataRefreshViewModel : VisitzViewModel
 	[ObservableProperty]
 	public string superMessage;
 
+	[ObservableProperty]
+	public StackOrientation orientation = StackOrientation.Vertical;
+
 	public override void Create()
 	{
 		base.Create();

--- a/visitz/Visitz/ViewModels/DataRefreshViewModel.cs
+++ b/visitz/Visitz/ViewModels/DataRefreshViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using CommunityToolkit.Mvvm.Messaging;
+using Visitz.Resources.Localization;
 using Visitz.Services;
 
 namespace Visitz.ViewModels;
@@ -35,7 +36,7 @@ internal partial class DataRefreshViewModel : VisitzViewModel
 
 	private void SetConnectivityMessage(NetworkAccess access)
 	{
-		SuperMessage = access == NetworkAccess.Internet ? "" : "Offline";
+		SuperMessage = access == NetworkAccess.Internet ? "" : LocalizedStrings.Offline;
 	}
 
 	[RelayCommand]

--- a/visitz/Visitz/ViewModels/NavRailViewModel.cs
+++ b/visitz/Visitz/ViewModels/NavRailViewModel.cs
@@ -64,10 +64,4 @@ public partial class NavRailViewModel : VisitzViewModel
     {
         await Navigator.GoToPage<SessionPage>(modal: true);
     }
-
-    [RelayCommand]
-    public static void RefreshCaseload()
-    {
-        WeakReferenceMessenger.Default.Send(GetAllDataForOfflineService.MakeStartMessage());
-    }
 }

--- a/visitz/Visitz/ViewModels/VisitzSnackbarViewModel.cs
+++ b/visitz/Visitz/ViewModels/VisitzSnackbarViewModel.cs
@@ -14,9 +14,27 @@ internal partial class VisitzSnackbarViewModel : VisitzViewModel
 	[ObservableProperty]
 	public Action action;
 
+	[ObservableProperty]
+	public bool actionVisible = false;
+
 	[RelayCommand]
 	public void ActionButtonSelected()
 	{
 		Action?.Invoke();
+	}
+
+	partial void OnActionChanged(Action value)
+	{
+		UpdateActionVisible();
+	}
+
+	partial void OnActionTextChanged(string value)
+	{
+		UpdateActionVisible();
+	}
+
+	void UpdateActionVisible()
+	{
+		ActionVisible = Action != null && !string.IsNullOrWhiteSpace(ActionText);
 	}
 }

--- a/visitz/Visitz/ViewModels/VisitzSnackbarViewModel.cs
+++ b/visitz/Visitz/ViewModels/VisitzSnackbarViewModel.cs
@@ -1,0 +1,22 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+
+namespace Visitz.ViewModels;
+
+internal partial class VisitzSnackbarViewModel : VisitzViewModel
+{
+	[ObservableProperty]
+	public string message;
+
+	[ObservableProperty]
+	public string actionText;
+
+	[ObservableProperty]
+	public Action action;
+
+	[RelayCommand]
+	public void ActionButtonSelected()
+	{
+		Action?.Invoke();
+	}
+}

--- a/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml
+++ b/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml
@@ -9,9 +9,10 @@
     x:Class="Visitz.Views.Caseload.DataRefreshButton"
 	x:DataType="viewModels:DataRefreshViewModel">
 
-	<VerticalStackLayout>
+	<StackLayout Orientation="{Binding Orientation}">
 		<Label
 			HorizontalOptions="Center"
+			VerticalOptions="Center"
 			Text="{Binding SuperMessage}"
 			TextColor="White"
 			IsVisible="{Binding SuperMessageVisible}" />
@@ -21,8 +22,9 @@
 			Style="{StaticResource FontIconButtonDarkMode}"
 			Size="Larger"
 			HorizontalOptions="Center"
+			VerticalOptions="Center"
 			FontFamily="MaterialIconsRoundedUnfilled"
 			Command="{Binding RefreshDataCommand}"
 			Text="{Static icons:MaterialIcons.Download_for_offline}" />
-	</VerticalStackLayout>
+	</StackLayout>
 </views:ViewModelContentView>

--- a/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml
+++ b/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<views:ViewModelContentView
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:controls="clr-namespace:Visitz.Controls"
+	xmlns:icons="clr-namespace:Visitz.FontIcons"
+	xmlns:viewModels="clr-namespace:Visitz.ViewModels"
+	xmlns:views="clr-namespace:Visitz.Views"
+    x:Class="Visitz.Views.Caseload.DataRefreshButton"
+	x:DataType="viewModels:DataRefreshViewModel">
+
+	<VerticalStackLayout>
+		<Label
+			HorizontalOptions="Center"
+			Text="{Binding SuperMessage}"
+			TextColor="White"
+			IsVisible="{Binding SuperMessageVisible}" />
+
+		<controls:FontIconButton
+			Style="{StaticResource FontIconButtonDarkMode}"
+			Size="Larger"
+			HorizontalOptions="Center"
+			FontFamily="MaterialIconsRoundedUnfilled"
+			Command="{Binding RefreshDataCommand}"
+			Text="{Static icons:MaterialIcons.Download_for_offline}" />
+	</VerticalStackLayout>
+</views:ViewModelContentView>

--- a/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml
+++ b/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml
@@ -17,6 +17,7 @@
 			IsVisible="{Binding SuperMessageVisible}" />
 
 		<controls:FontIconButton
+			x:Name="RefreshButton"
 			Style="{StaticResource FontIconButtonDarkMode}"
 			Size="Larger"
 			HorizontalOptions="Center"

--- a/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml.cs
+++ b/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml.cs
@@ -5,6 +5,14 @@ namespace Visitz.Views.Caseload;
 
 public partial class DataRefreshButton : ViewModelContentView
 {
+	new DataRefreshViewModel ViewModel => base.ViewModel as DataRefreshViewModel;
+
+	public StackOrientation Orientation
+	{
+		get => ViewModel.Orientation;
+		set => ViewModel.Orientation = value;
+	}
+
 	public DataRefreshButton() : base(ServiceProvider.GetService<DataRefreshViewModel>())
 	{
 		InitializeComponent();

--- a/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml.cs
+++ b/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml.cs
@@ -1,3 +1,4 @@
+using Visitz.FontIcons;
 using Visitz.ViewModels;
 
 namespace Visitz.Views.Caseload;
@@ -8,5 +9,27 @@ public partial class DataRefreshButton : ViewModelContentView
 	{
 		InitializeComponent();
 		BindingContext = ViewModel;
+
+		SetIconByNetworkAccess(Connectivity.Current.NetworkAccess);
+		Connectivity.Current.ConnectivityChanged += Current_ConnectivityChanged;
+	}
+
+	protected override void Destroying()
+	{
+		Connectivity.Current.ConnectivityChanged -= Current_ConnectivityChanged;
+
+		base.Destroying();
+	}
+
+	private void Current_ConnectivityChanged(object sender, ConnectivityChangedEventArgs e)
+	{
+		SetIconByNetworkAccess(e.NetworkAccess);
+	}
+
+	private void SetIconByNetworkAccess(NetworkAccess networkAccess)
+	{
+		RefreshButton.Text = networkAccess == NetworkAccess.Internet
+			? MaterialIcons.Download_for_offline
+			: MaterialIcons.File_download_off;
 	}
 }

--- a/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml.cs
+++ b/visitz/Visitz/Views/Caseload/DataRefreshButton.xaml.cs
@@ -1,0 +1,12 @@
+using Visitz.ViewModels;
+
+namespace Visitz.Views.Caseload;
+
+public partial class DataRefreshButton : ViewModelContentView
+{
+	public DataRefreshButton() : base(ServiceProvider.GetService<DataRefreshViewModel>())
+	{
+		InitializeComponent();
+		BindingContext = ViewModel;
+	}
+}

--- a/visitz/Visitz/Views/Entity/EntitySafetyAssessView.xaml.cs
+++ b/visitz/Visitz/Views/Entity/EntitySafetyAssessView.xaml.cs
@@ -60,7 +60,7 @@ public partial class EntitySafetyAssessView : ViewModelContentView, ICaseloadIte
     {
 		if (await PromptDiscard())
 		{
-			ViewModel.Reset();
+			await ViewModel.Reset();
 			SnackbarHandler.ShowText(LocalizedStrings.DiscardedSafetyAssessmentDraft);
 		}
     }

--- a/visitz/Visitz/Views/Entity/EntitySafetyAssessView.xaml.cs
+++ b/visitz/Visitz/Views/Entity/EntitySafetyAssessView.xaml.cs
@@ -61,7 +61,7 @@ public partial class EntitySafetyAssessView : ViewModelContentView, ICaseloadIte
 		if (await PromptDiscard())
 		{
 			ViewModel.Reset();
-			await Toast.Make(LocalizedStrings.DiscardedSafetyAssessmentDraft).Show();
+			SnackbarHandler.ShowText(LocalizedStrings.DiscardedSafetyAssessmentDraft);
 		}
     }
 

--- a/visitz/Visitz/Views/ISnackbarPresenter.cs
+++ b/visitz/Visitz/Views/ISnackbarPresenter.cs
@@ -1,0 +1,8 @@
+namespace Visitz.Views;
+
+internal interface ISnackbarPresenter
+{
+	void SetSnackbar(VisitzSnackbar snackbar);
+
+	void Snackbar_ShouldClose(object sender, EventArgs e);
+}

--- a/visitz/Visitz/Views/Navigation/HorizontalNavRailView.xaml
+++ b/visitz/Visitz/Views/Navigation/HorizontalNavRailView.xaml
@@ -30,7 +30,8 @@
 		</selView:SelectionList>
 
 		<caseload:DataRefreshButton
-			Grid.Row="3"
+			Grid.Column="2"
+			Orientation="Horizontal"
 			HorizontalOptions="Center" />
 
 		<Image 

--- a/visitz/Visitz/Views/Navigation/HorizontalNavRailView.xaml
+++ b/visitz/Visitz/Views/Navigation/HorizontalNavRailView.xaml
@@ -2,6 +2,7 @@
 <views:ViewModelContentView
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:caseload="clr-namespace:Visitz.Views.Caseload"
 	xmlns:controls="clr-namespace:Visitz.Controls"
 	xmlns:icons="clr-namespace:Visitz.FontIcons"
 	xmlns:views="clr-namespace:Visitz.Views"
@@ -28,14 +29,9 @@
 			</selView:SelectionList.ItemTemplate>
 		</selView:SelectionList>
 
-		<controls:FontIconButton
-			Grid.Column="2"
-			Style="{StaticResource FontIconButtonDarkMode}"
-			Size="Larger"
-			VerticalOptions="Center"
-			FontFamily="MaterialIconsRoundedUnfilled"
-			Command="{Binding RefreshCaseloadCommand}"
-			Text="{Static icons:MaterialIcons.Download_for_offline}" />
+		<caseload:DataRefreshButton
+			Grid.Row="3"
+			HorizontalOptions="Center" />
 
 		<Image 
 			Grid.Column="3"

--- a/visitz/Visitz/Views/Navigation/VerticalNavRailView.xaml
+++ b/visitz/Visitz/Views/Navigation/VerticalNavRailView.xaml
@@ -49,6 +49,7 @@
 
 		<caseload:DataRefreshButton
 			Grid.Row="3"
+			Orientation="Vertical"
 			HorizontalOptions="Center" />
 
 		<Image 

--- a/visitz/Visitz/Views/Navigation/VerticalNavRailView.xaml
+++ b/visitz/Visitz/Views/Navigation/VerticalNavRailView.xaml
@@ -3,6 +3,7 @@
 	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	xmlns:behaviors="clr-namespace:Visitz.Behaviors"
+	xmlns:caseload="clr-namespace:Visitz.Views.Caseload"
 	xmlns:controls="clr-namespace:Visitz.Controls"
 	xmlns:nav="clr-namespace:Visitz.Views.Navigation"
 	xmlns:icons="clr-namespace:Visitz.FontIcons"
@@ -46,14 +47,9 @@
 			</selView:SelectionList.ItemTemplate>
 		</selView:SelectionList>
 
-		<controls:FontIconButton
+		<caseload:DataRefreshButton
 			Grid.Row="3"
-			Style="{StaticResource FontIconButtonDarkMode}"
-			Size="Larger"
-			HorizontalOptions="Center"
-			FontFamily="MaterialIconsRoundedUnfilled"
-			Command="{Binding RefreshCaseloadCommand}"
-			Text="{Static icons:MaterialIcons.Download_for_offline}" />
+			HorizontalOptions="Center" />
 
 		<Image 
 			Grid.Row="4"

--- a/visitz/Visitz/Views/VisitzSnackbar.xaml
+++ b/visitz/Visitz/Views/VisitzSnackbar.xaml
@@ -18,7 +18,7 @@
 		
 		<HorizontalStackLayout
 			Padding="16"
-			Spacing="4">
+			Spacing="8">
 			
 			<Label
 				Text="{Binding Message}"
@@ -28,6 +28,7 @@
 
 			<Button
 				Style="{StaticResource SecondaryButtonDark}"
+				Padding="8, -1"
 				BorderWidth="0"
 				TextColor="White"
 				FontFamily="BCSansBold"

--- a/visitz/Visitz/Views/VisitzSnackbar.xaml
+++ b/visitz/Visitz/Views/VisitzSnackbar.xaml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<views:ViewModelContentView
+	xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	xmlns:viewModels="clr-namespace:Visitz.ViewModels"
+	xmlns:views="clr-namespace:Visitz.Views"
+    x:Class="Visitz.Views.VisitzSnackbar"
+	x:DataType="viewModels:VisitzSnackbarViewModel"
+	BackgroundColor="Transparent">
+
+	<Border
+		VerticalOptions="Start"
+		HorizontalOptions="Start"
+		BackgroundColor="{StaticResource BC_TextColor}"
+		Stroke="Transparent"
+		StrokeThickness="0"
+		StrokeShape="RoundRectangle 4">
+		
+		<HorizontalStackLayout
+			Padding="16,8,0,8"
+			Spacing="4">
+			
+			<Label
+				Text="{Binding Message}"
+				TextColor="White"
+				VerticalOptions="Center" 
+				HorizontalOptions="Start" />
+
+			<Button
+				Style="{StaticResource SecondaryButtonDark}"
+				BorderWidth="0"
+				TextColor="White"
+				FontFamily="BCSansBold"
+				Command="{Binding ActionButtonSelectedCommand}"
+				Text="{Binding ActionText}" />
+		</HorizontalStackLayout>
+	</Border>
+</views:ViewModelContentView>

--- a/visitz/Visitz/Views/VisitzSnackbar.xaml
+++ b/visitz/Visitz/Views/VisitzSnackbar.xaml
@@ -17,7 +17,7 @@
 		StrokeShape="RoundRectangle 4">
 		
 		<HorizontalStackLayout
-			Padding="16,8,0,8"
+			Padding="16"
 			Spacing="4">
 			
 			<Label
@@ -32,7 +32,8 @@
 				TextColor="White"
 				FontFamily="BCSansBold"
 				Command="{Binding ActionButtonSelectedCommand}"
-				Text="{Binding ActionText}" />
+				Text="{Binding ActionText}"
+				IsVisible="{Binding ActionVisible}" />
 		</HorizontalStackLayout>
 	</Border>
 </views:ViewModelContentView>

--- a/visitz/Visitz/Views/VisitzSnackbar.xaml.cs
+++ b/visitz/Visitz/Views/VisitzSnackbar.xaml.cs
@@ -1,0 +1,59 @@
+using Visitz.ViewModels;
+
+namespace Visitz.Views;
+
+public partial class VisitzSnackbar : ViewModelContentView
+{
+	new VisitzSnackbarViewModel ViewModel => base.ViewModel as VisitzSnackbarViewModel;
+
+	public string Message
+	{
+		get => ViewModel.Message;
+		set => ViewModel.Message = value;
+	}
+
+	public string ActionText
+	{
+		get => ViewModel.ActionText;
+		set => ViewModel.ActionText = value;
+	}
+
+	public Action Action
+	{
+		get => ViewModel.Action;
+		set
+		{
+			ViewModel.Action = () =>
+			{
+				ShouldClose?.Invoke(this, EventArgs.Empty);
+				value?.Invoke();
+			};
+		}
+	}
+
+	public event EventHandler ShouldClose;
+
+	TimeSpan _duration;
+
+	public TimeSpan Duration
+	{
+		get => _duration;
+		set
+		{
+			_duration = value;
+			_ = DelayFireShouldClose();
+		}
+	}
+
+	public VisitzSnackbar() : base(ServiceProvider.GetService<VisitzSnackbarViewModel>())
+	{
+		InitializeComponent();
+		BindingContext = ViewModel;
+	}
+
+	async Task DelayFireShouldClose()
+	{
+		await Task.Delay(_duration, CancellationToken.None);
+		ShouldClose?.Invoke(this, EventArgs.Empty);
+	}
+}

--- a/visitz/Visitz/VisitzConfig/VisitzScreens.cs
+++ b/visitz/Visitz/VisitzConfig/VisitzScreens.cs
@@ -19,6 +19,9 @@ namespace Visitz.VisitzConfig
 
             builder.Services.AddSingleton<NavRailViewModel>();
 
+			builder.Services.AddTransient<VisitzSnackbar>();
+			builder.Services.AddTransient<VisitzSnackbarViewModel>();
+
 			builder.Services.AddTransient<DataRefreshButton>();
 			builder.Services.AddTransient<DataRefreshViewModel>();
 

--- a/visitz/Visitz/VisitzConfig/VisitzScreens.cs
+++ b/visitz/Visitz/VisitzConfig/VisitzScreens.cs
@@ -19,7 +19,10 @@ namespace Visitz.VisitzConfig
 
             builder.Services.AddSingleton<NavRailViewModel>();
 
-            builder.Services.AddSingleton<CaseloadContainerView>();
+			builder.Services.AddTransient<DataRefreshButton>();
+			builder.Services.AddTransient<DataRefreshViewModel>();
+
+			builder.Services.AddSingleton<CaseloadContainerView>();
             builder.Services.AddSingleton<WatermarkView>();
 
             builder.Services.AddSingleton<CaseloadView>();


### PR DESCRIPTION
[STRY0030442 - Develop: Offline indicator](https://bcsocialsector.service-now.com/rm_story.do?sys_id=957692d787394a143b837446dabb3557&sysparm_view=&sysparm_time=1715194724746)

When no internet available, the refresh icon is changed with an "Offline" message above it. Selecting it displays a Snackbar, with the option of viewing more information in a dialog box.

Created a custom Snackbar component so it looks consistent across platforms. Decided to do this instead of the MAUI CommunityToolkit's Snackbar component because it uses regular Windows notifications—and Windows notifications don't give the same real-time/dialog-like feedback that traditional Snackbars do.

Replaced the toast usage when discarding safety assessments with this new Snackbar component.