### PR TITLE
Fix missing note period crash

### DIFF
--- a/visitz/Visitz/Services/GetNotesService.cs
+++ b/visitz/Visitz/Services/GetNotesService.cs
@@ -1,4 +1,4 @@
-﻿using Visitz.Services.Messages;
+using Visitz.Services.Messages;
 using Visitz.Storage;
 using VisitzApi;
 using VisitzModel.Models;
@@ -48,20 +48,9 @@ namespace Visitz.Services
             var newNotes = NoteItem.FromApiEntities(id, notesFromApi);
 
             using var realm = await VisitzRealms.GetIcmDataRealmAsync();
-            var currentNotes = NoteItem.GetNotesByEntityId(realm, id);
-            var deletedNotes = currentNotes.ExceptBy(newNotes.Select(NoteSelector), NoteSelector);
-
-            await realm.WriteAsync(() =>
-            {
-                foreach (var deletedNote in deletedNotes)
-                    realm.Remove(deletedNote);
-
-                realm.Add(newNotes, update: true);
-            });
+			await NoteItem.UpsertNotesAsync(realm, id, newNotes);
 
             ResultCode = Result.Successful;
         }
-
-        static string NoteSelector(NoteItem note) => note.FullID;
     }
 }

--- a/visitz/Visitz/Services/GetNotesService.cs
+++ b/visitz/Visitz/Services/GetNotesService.cs
@@ -47,10 +47,10 @@ namespace Visitz.Services
             var notesFromApi = await Vpi.GetNotesAsync(id, entityType);
             var newNotes = NoteItem.FromApiEntities(id, notesFromApi);
 
-            using var realm = await VisitzRealms.GetIcmDataRealmAsync();
-			await NoteItem.UpsertNotesAsync(realm, id, newNotes);
+			using var realm = await VisitzRealms.GetIcmDataRealmAsync();
+			await NoteItem.UpsertNotesAsync(realm, id, entityType, newNotes);
 
             ResultCode = Result.Successful;
         }
-    }
+	}
 }

--- a/visitz/VisitzModel/Models/NoteItem.cs
+++ b/visitz/VisitzModel/Models/NoteItem.cs
@@ -1,4 +1,4 @@
-﻿using Realms;
+using Realms;
 using System.Globalization;
 using VisitzApi.Models;
 
@@ -84,7 +84,23 @@ namespace VisitzModel.Models
                 .Select((note, index) => FromApiEntity(icmId, note, index + 1));
         }
 
-        public static string NotePeriodFrom(DateTime dateTime)
+		public static async Task UpsertNotesAsync(Realm realm, string entityId, IEnumerable<NoteItem> newNotes)
+		{
+			var currentNotes = GetNotesByEntityId(realm, entityId);
+			var deletedNotes = currentNotes.ExceptBy(newNotes.Select(NoteSelector), NoteSelector);
+
+			await realm.WriteAsync(() =>
+			{
+				foreach (var deletedNote in deletedNotes)
+					realm.Remove(deletedNote);
+
+				realm.Add(newNotes, update: true);
+			});
+		}
+
+		static string NoteSelector(NoteItem note) => note.FullID;
+
+		public static string NotePeriodFrom(DateTime dateTime)
         {
             return NotePeriodFrom(new DateTimeOffset(dateTime));
         }

--- a/visitz/VisitzModel/Models/NoteItem.cs
+++ b/visitz/VisitzModel/Models/NoteItem.cs
@@ -1,6 +1,8 @@
 using Realms;
 using System.Globalization;
 using VisitzApi.Models;
+using VisitzModel.Extensions.EntityTypes;
+using VisitzModel.Models.EntityTypes;
 
 namespace VisitzModel.Models
 {
@@ -109,8 +111,16 @@ namespace VisitzModel.Models
                 .Select((note, index) => FromApiEntity(icmId, note, index + 1));
         }
 
-		public static async Task UpsertNotesAsync(Realm realm, string entityId, IEnumerable<NoteItem> newNotes)
+		public static async Task UpsertNotesAsync(
+			Realm realm,
+			string entityId,
+			string entityType,
+			IEnumerable<NoteItem> newNotes)
 		{
+			if (entityType.ParseEntityType() == EntityType.Case)
+				// Case notes older <= 2012 may have a blank note period.
+				newNotes = SimulateNotePeriods(newNotes);
+
 			var currentNotes = GetNotesByEntityId(realm, entityId);
 			var deletedNotes = currentNotes.ExceptBy(newNotes.Select(NoteSelector), NoteSelector);
 
@@ -121,6 +131,17 @@ namespace VisitzModel.Models
 
 				realm.Add(newNotes, update: true);
 			});
+		}
+
+		static List<NoteItem> SimulateNotePeriods(IEnumerable<NoteItem> notes)
+		{
+			var simulatedPeriodNotes = notes.ToList();
+
+			foreach (var note in simulatedPeriodNotes)
+				if (string.IsNullOrWhiteSpace(note.NotePeriod))
+					note.NotePeriod = NotePeriodFrom(DateTimeOffset.Parse(note.CreatedDate));
+
+			return simulatedPeriodNotes;
 		}
 
 		static string NoteSelector(NoteItem note) => note.FullID;

--- a/visitz/VisitzModel/Models/NoteItem.cs
+++ b/visitz/VisitzModel/Models/NoteItem.cs
@@ -9,7 +9,10 @@ namespace VisitzModel.Models
     /// </summary>
     public partial class NoteItem : IRealmObject
     {
-        private static readonly string IcmNotePeriodDateFormat = "MMM yyyy";
+		private const string NotePeriodName = "NotePeriod";
+		private const string CreatedDateName = "CreatedDate";
+
+		private static readonly string IcmNotePeriodDateFormat = "MMM yyyy";
         private static readonly string NoteWrapperTimestampFormat = "yyyy-MMM-dd hh:mm:ss tt";
         private static readonly string Separator = "────";
 
@@ -37,8 +40,36 @@ namespace VisitzModel.Models
         [Indexed]
         public string IcmId { get; set; }
 
-        public string NotePeriod { get; set; }
-        public string CreatedDate { get; set; }
+		[MapTo(NotePeriodName)]
+		private string NotePeriodField {  get; set; }
+        public string NotePeriod
+		{
+			get => NotePeriodField;
+			set
+			{
+				NotePeriodField = value;
+
+				NotePeriodDateTime = value?.Length > 0
+					? DateTimeOffset.Parse(value)
+					: DateTimeOffset.MinValue;
+			}
+		}
+
+		[MapTo(CreatedDateName)]
+		private string CreatedDateField { get; set; }
+		public string CreatedDate
+		{
+			get => CreatedDateField;
+			set
+			{
+				CreatedDateField = value;
+
+				CreatedDateTime = value?.Length > 0
+					? DateTimeOffset.Parse(value)
+					: DateTimeOffset.MinValue;
+			}
+		}
+
         public string Content { get; set; }
         public int PageNumber { get; set; }
 
@@ -67,12 +98,6 @@ namespace VisitzModel.Models
                 CreatedDate = note.CreatedDate,
                 Content = note.Content,
                 PageNumber = pageNumber,
-                NotePeriodDateTime = note.NotePeriod?.Length > 0
-                    ? DateTimeOffset.Parse(note.NotePeriod)
-                    : DateTimeOffset.MinValue,
-                CreatedDateTime = note.CreatedDate?.Length > 0
-                    ? DateTimeOffset.Parse(note.CreatedDate)
-                    : DateTimeOffset.MinValue,
             };
         }
 


### PR DESCRIPTION
[STRY0030268 - Bug: App crashes when viewing notes without note periods](https://bcsocialsector.service-now.com/rm_story.do?sys_id=d1f808a78765ca983b837446dabb3590&sysparm_view=&sysparm_time=1715811328053)