### PR TITLE
Prompt to delete draft orphans

### DIFF
--- a/visitz/Visitz/Converters/DateTimeShortTimestampConverter.cs
+++ b/visitz/Visitz/Converters/DateTimeShortTimestampConverter.cs
@@ -1,0 +1,22 @@
+using System.Globalization;
+using VisitzModel.Formats;
+
+namespace Visitz.Converters;
+
+internal class DateTimeShortTimestampConverter : IValueConverter
+{
+	public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		if (value == null)
+			return null;
+
+		var timestamp = (DateTime)value;
+
+		return timestamp.ToString(IcmDateFormats.BasicTimestampShort, CultureInfo.InvariantCulture);
+	}
+
+	public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+	{
+		return null; // Not converting back, only displaying
+	}
+}

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -741,7 +741,7 @@ namespace Visitz.Resources.Localization {
         /// <summary>
         ///   Looks up a localized string similar to You&apos;ve successfully logged in.
         ///
-        ///However, you currently aren&apos;t authorized to use MCFD Mobility. Use the &quot;Request Access&quot; button below to submit a request. 
+        ///Use the &quot;Request Access&quot; button below to submit a request for authorization to use the app.
         ///
         ///If that doesn&apos;t work, request access by emailing .
         /// </summary>

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -133,6 +133,15 @@ namespace Visitz.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Cancel and keep draft.
+        /// </summary>
+        public static string CancelAndKeepDraft {
+            get {
+                return ResourceManager.GetString("CancelAndKeepDraft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Caseload.
         /// </summary>
         public static string Caseload {
@@ -389,6 +398,28 @@ namespace Visitz.Resources.Localization {
         public static string DiscardSafetyAssessmentDraftDescription {
             get {
                 return ResourceManager.GetString("DiscardSafetyAssessmentDraftDescription", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Discard unlinked draft.
+        /// </summary>
+        public static string DiscardUnlinkedDraft {
+            get {
+                return ResourceManager.GetString("DiscardUnlinkedDraft", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to You are not assigned to {0} &apos;{1}&apos;. To continue working on drafts for this record you must be assigned.
+        ///
+        ///If you select &apos;Cancel and keep draft&apos;, the draft will remain on your device.
+        ///
+        ///Do you want to discard this unlinked draft permanently?.
+        /// </summary>
+        public static string DiscardUnlinkedDraftDesc {
+            get {
+                return ResourceManager.GetString("DiscardUnlinkedDraftDesc", resourceCulture);
             }
         }
         

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -200,7 +200,7 @@ Logging out won't affect your unpublished notes.</value>
   <data name="LoginSuccessButUnauth" xml:space="preserve">
     <value>You've successfully logged in.
 
-However, you currently aren't authorized to use MCFD Mobility. Use the "Request Access" button below to submit a request. 
+Use the "Request Access" button below to submit a request for authorization to use the app.
 
 If that doesn't work, request access by emailing </value>
   </data>

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -702,4 +702,19 @@ If you have any questions about the collection, use, or disclosure of this infor
   <data name="DiscardNoteDraftDescription" xml:space="preserve">
     <value>Are you sure you want to discard this note draft? You won't be able to recover it.</value>
   </data>
+  <data name="CancelAndKeepDraft" xml:space="preserve">
+    <value>Cancel and keep draft</value>
+  </data>
+  <data name="DiscardUnlinkedDraft" xml:space="preserve">
+    <value>Discard unlinked draft</value>
+  </data>
+  <data name="DiscardUnlinkedDraftDesc" xml:space="preserve">
+    <value>You are not assigned to {0} '{1}'. To continue working on drafts for this record you must be assigned.
+
+If you select 'Cancel and keep draft', the draft will remain on your device.
+
+Do you want to discard this unlinked draft permanently?</value>
+    <comment>0 = Entity type
+1 = Entity display text if available, otherwise Entity ID number</comment>
+  </data>
 </root>

--- a/visitz/Visitz/Services/GetCaseloadService.cs
+++ b/visitz/Visitz/Services/GetCaseloadService.cs
@@ -46,7 +46,7 @@ namespace Visitz.Services
             await CaseloadItem.ReplaceCaseloadWithAsync(realm, caseloadContent);
 
             ResultCode = Result.Successful;
-			LastUpdated.Set(GetId(), DateTimeExtensions.LocalNow);
+			await MainThread.InvokeOnMainThreadAsync(() => LastUpdated.Set(GetId(), DateTimeExtensions.LocalNow));
         }
 
         public override string GetId()

--- a/visitz/Visitz/Services/GetNotesForRangeService.cs
+++ b/visitz/Visitz/Services/GetNotesForRangeService.cs
@@ -57,26 +57,26 @@ namespace Visitz.Services
                 await ServiceHandler.TryRunServiceAsync(GetNotesService.MakeStartMessage(id, entityType));
                 successIds.Add(id);
             }
-            catch
+            catch (Exception ex)
             {
-                erroredIds.Add(id);
+                erroredIds.Add(id + " -> " + ex.Message);
             }
 		}
 	}
 
-    public class PartialErrorException(List<string> successIds, List<string> errorIds) 
-        : Exception(MakeMessage(errorIds))
+    public class PartialErrorException(List<string> successIds, List<string> errors) 
+        : Exception(MakeMessage(errors))
     {
         public List<string> SuccessIds { get; set; } = successIds;
 
-        public List<string> ErrorIds { get; set; } = errorIds;
+        public List<string> ErrorIds { get; set; } = errors;
 
-        public static string MakeMessage(List<string> errorIds)
+        public static string MakeMessage(List<string> errors)
         {
-            StringBuilder sb = new($"{nameof(GetNotesForRangeService)} error for IDs:\n\n");
+            StringBuilder sb = new($"{nameof(GetNotesForRangeService)} errors:\n\n");
 
-            foreach (var id in errorIds.Order())
-                sb.AppendLine($"• \t{id}");
+            foreach (var error in errors.Order())
+                sb.AppendLine($"• {error}");
 
             return sb.ToString();
         }

--- a/visitz/Visitz/Services/ServiceHandler.cs
+++ b/visitz/Visitz/Services/ServiceHandler.cs
@@ -1,11 +1,12 @@
 using CommunityToolkit.Mvvm.Messaging;
+using System.Collections.Concurrent;
 using Visitz.Services.Messages;
 
 namespace Visitz.Services
 {
     public class ServiceHandler : IRecipient<StartServiceMessage>
     {
-        readonly IDictionary<string, VisitzService> Services = new Dictionary<string, VisitzService>();
+        readonly ConcurrentDictionary<string, VisitzService> Services = [];
 
         public ServiceHandler()
         {
@@ -47,7 +48,7 @@ namespace Visitz.Services
                 }
                 finally
                 {
-                    Services.Remove(startMessage.ServiceId);
+                    Services.TryRemove(startMessage.ServiceId, out var _);
                 }
             }
             else

--- a/visitz/Visitz/ViewModels/Drafts/DraftsListViewModel.cs
+++ b/visitz/Visitz/ViewModels/Drafts/DraftsListViewModel.cs
@@ -105,6 +105,19 @@ internal partial class DraftsListViewModel : VisitzViewModel
 
 	public static async Task DeleteDraft(IDraftItem draft)
 	{
-		await draft.Realm.WriteAsync(() => draft.Realm.Remove(draft));
+		var realm = draft.Realm;
+
+		await realm.WriteAsync(() =>
+		{
+			if (draft is AssessmentDraft)
+			{
+				var assessment = SafetyAssessment.FindByIncidentNumber(realm, draft.RelatedEntityId);
+
+				if (assessment != null)
+					realm.Remove(assessment);
+			}
+
+			realm.Remove(draft);
+		});
 	}
 }

--- a/visitz/Visitz/ViewModels/Drafts/DraftsListViewModel.cs
+++ b/visitz/Visitz/ViewModels/Drafts/DraftsListViewModel.cs
@@ -84,9 +84,14 @@ internal partial class DraftsListViewModel : VisitzViewModel
 		var caseloadItem = DataRealm
 			.All<CaseloadItem>()
 			.Where(item => item.CaseIncidentNumber == draftItem.RelatedEntityId)
-			.FirstOrDefault(); 
+			.FirstOrDefault();
 
-		var caseloadNav = new CaseloadItemSelectedMessage(caseloadItem, SectionToOpen);
+		NavigateTo(caseloadItem, SectionToOpen);
+	}
+
+	static void NavigateTo(CaseloadItem caseloadItem, EntitySection section)
+	{
+		var caseloadNav = new CaseloadItemSelectedMessage(caseloadItem, section);
 		StrongReferenceMessenger.Default.Send(caseloadNav);
 
 		var appNav = new AppNavMessage(new() { ContentViewType = typeof(CaseloadContainerView) });

--- a/visitz/Visitz/ViewModels/Drafts/DraftsListViewModel.cs
+++ b/visitz/Visitz/ViewModels/Drafts/DraftsListViewModel.cs
@@ -24,6 +24,8 @@ internal partial class DraftsListViewModel : VisitzViewModel
 
 	EntitySection SectionToOpen { get; set; }
 
+	public event EventHandler<IDraftItem> SelectedItemRelatedMissing;
+
 	public override async void Create()
 	{
 		base.Create();
@@ -86,7 +88,10 @@ internal partial class DraftsListViewModel : VisitzViewModel
 			.Where(item => item.CaseIncidentNumber == draftItem.RelatedEntityId)
 			.FirstOrDefault();
 
-		NavigateTo(caseloadItem, SectionToOpen);
+		if (caseloadItem != null)
+			NavigateTo(caseloadItem, SectionToOpen);
+		else
+			SelectedItemRelatedMissing?.Invoke(this, draftItem);
 	}
 
 	static void NavigateTo(CaseloadItem caseloadItem, EntitySection section)
@@ -96,5 +101,10 @@ internal partial class DraftsListViewModel : VisitzViewModel
 
 		var appNav = new AppNavMessage(new() { ContentViewType = typeof(CaseloadContainerView) });
 		StrongReferenceMessenger.Default.Send(appNav);
+	}
+
+	public static async Task DeleteDraft(IDraftItem draft)
+	{
+		await draft.Realm.WriteAsync(() => draft.Realm.Remove(draft));
 	}
 }

--- a/visitz/Visitz/ViewModels/NavRailViewModel.cs
+++ b/visitz/Visitz/ViewModels/NavRailViewModel.cs
@@ -105,7 +105,7 @@ public partial class NavRailViewModel : VisitzViewModel
 		realmCount.CountChanged += RealmCount_CountChanged;
 
 		realmCount.Subscribe<NoteDraft>(await VisitzRealms.GetNoteDraftsRealmAsync());
-		realmCount.Subscribe<SafetyAssessment>(await VisitzRealms.GetSafetyAssessmentDraftRealmAsync());
+		realmCount.Subscribe<AssessmentDraft>(await VisitzRealms.GetSafetyAssessmentDraftRealmAsync());
 	}
 
     partial void OnSelectedNavItemChanged(NavItem value)

--- a/visitz/Visitz/Views/Drafts/DraftsList.xaml
+++ b/visitz/Visitz/Views/Drafts/DraftsList.xaml
@@ -65,7 +65,7 @@
 								Margin="10">
 
 								<Grid.Resources>
-									<converters:DateTimeOffsetThatDayConverter x:Key="ThatDayConverter" />
+									<converters:DateTimeShortTimestampConverter x:Key="ShortTimestampConverter" />
 								</Grid.Resources>
 							
 								<Label 
@@ -83,7 +83,7 @@
 								<Label 
 									Grid.Column="2"
 									VerticalOptions="Start"
-									Text="{Binding LastUpdated.LocalDateTime, StringFormat='{0:yyyy-MMM-dd}'}"
+									Text="{Binding LastUpdated.LocalDateTime, Converter={StaticResource ShortTimestampConverter}}"
 									TextColor="{StaticResource BC_TextColor_Lighter}" />
 
 								<tagViews:EntityTypeBadge 

--- a/visitz/Visitz/Views/Drafts/DraftsList.xaml.cs
+++ b/visitz/Visitz/Views/Drafts/DraftsList.xaml.cs
@@ -1,12 +1,57 @@
+using Visitz.Resources.Localization;
 using Visitz.ViewModels.Drafts;
+using VisitzModel.Extensions.EntityTypes;
+using VisitzModel.Models.Drafts;
 
 namespace Visitz.Views.Drafts;
 
 public partial class DraftsList : ViewModelContentView
 {
+	new DraftsListViewModel ViewModel => base.ViewModel as DraftsListViewModel;
+
 	public DraftsList() : base(ServiceProvider.GetService<DraftsListViewModel>())
 	{
 		InitializeComponent();
 		BindingContext = ViewModel;
+	}
+
+	protected override void Creating()
+	{
+		base.Creating();
+
+		ViewModel.SelectedItemRelatedMissing += ViewModel_SelectedItemRelatedMissing;
+	}
+
+	protected override void Destroying()
+	{
+		base.Destroying();
+
+		ViewModel.SelectedItemRelatedMissing -= ViewModel_SelectedItemRelatedMissing;
+	}
+
+	void ViewModel_SelectedItemRelatedMissing(object sender, IDraftItem draft)
+	{
+		_ = DoPromptDiscardAsync(draft);
+	}
+
+	static async Task DoPromptDiscardAsync(IDraftItem draft)
+	{
+		if (await PromptDiscardDraftAsync(draft))
+			await DraftsListViewModel.DeleteDraft(draft);
+	}
+
+	static async Task<bool> PromptDiscardDraftAsync(IDraftItem draft)
+	{
+		string message = string.Format(
+			LocalizedStrings.DiscardUnlinkedDraftDesc,
+			draft.RelatedEntityType.GetDisplayString(),
+			!string.IsNullOrWhiteSpace(draft.DraftLocation) ? draft.DraftLocation : draft.RelatedEntityId
+		);
+
+		return await Navigator.CurrentOpenPage.DisplayAlert(
+			LocalizedStrings.DiscardUnlinkedDraft,
+			message,
+			LocalizedStrings.DiscardDraft,
+			LocalizedStrings.CancelAndKeepDraft);
 	}
 }

--- a/visitz/VisitzModel/Formats/IcmDateFormats.cs
+++ b/visitz/VisitzModel/Formats/IcmDateFormats.cs
@@ -3,5 +3,6 @@ namespace VisitzModel.Formats;
 public static class IcmDateFormats
 {
 	public static readonly string BasicTimestamp = "yyyy-MMM-dd hh:mm:ss tt";
+	public static readonly string BasicTimestampShort = "yyyy-MMM-dd";
 	public static readonly string NotePeriod = "MMM yyyy";
 }


### PR DESCRIPTION
[STRY0031157 - Prompt to delete orphaned draft items](https://bcsocialsector.service-now.com/rm_story.do?sys_id=6c0f3d0587e64ad03b837446dabb3578&sysparm_view=&sysparm_time=1717445739725)

Plus additional changes:

- GetNotesForRangeService now includes exception messages when individual calls to GetNotesService fail
- Fixed ServiceHandler to now use a ConcurrentDictionary
- Fixed realmCount subscription to look for AssessmentDrafts instead of SafetyAssessments