### PR TITLE
Fix Safety Assessment publish crash

### DIFF
--- a/visitz/Visitz/ViewModels/Entity/EntitySafetyAssessViewModel.cs
+++ b/visitz/Visitz/ViewModels/Entity/EntitySafetyAssessViewModel.cs
@@ -144,7 +144,7 @@ public partial class EntitySafetyAssessViewModel : VisitzViewModel, ICaseloadIte
 
 		if (!Assessment.IsManaged)
 			DraftItem = await AssessmentDraft.Upsert(Realm, Assessment, CaseloadItem.DisplayName);
-		else if (DraftItem != null)
+		else if (DraftItem?.IsValid ?? false)
 			DraftItem.LastUpdatedBinding = DateTimeOffset.Now;
 
 		CanDiscard = Assessment.IsManaged;

--- a/visitz/Visitz/ViewModels/SafetyAssessmentPublishViewModel.cs
+++ b/visitz/Visitz/ViewModels/SafetyAssessmentPublishViewModel.cs
@@ -71,7 +71,7 @@ internal partial class SafetyAssessmentPublishViewModel : PublishViewModel, IRec
 
     private async Task DiscardSentDraft()
     {
-        await SafetyAssessment.Delete(Assessment.Realm, Assessment);
+        await AssessmentDraft.TryDeleteAsync(Assessment);
     }
 
     private void RedirectToDetails()


### PR DESCRIPTION
[STRY0031602 - Defect: App crashes while publishing Safety Assessments to ICM](https://bcsocialsector.service-now.com/rm_story.do?sys_id=c7d67bf41b7a8a941c6321f7ec4bcb69&sysparm_view=&sysparm_time=1718292725432)