### PR TITLE
Fix auto-type note crash

### DIFF
--- a/visitz/Visitz/ViewModels/NoteEntryViewModel.cs
+++ b/visitz/Visitz/ViewModels/NoteEntryViewModel.cs
@@ -121,7 +121,7 @@ namespace Visitz.ViewModels
 			int length = e.NewTextValue?.Length ?? 0;
 
 			if (length > 0 && !NoteDraft.IsManaged)
-				await Realm.WriteAsync(() => Realm.Add(NoteDraft));
+				Realm.Write(() => Realm.Add(NoteDraft));
 
 			if (TextIsInvalid(e))
             {

--- a/visitz/Visitz/ViewModels/NoteEntryViewModel.cs
+++ b/visitz/Visitz/ViewModels/NoteEntryViewModel.cs
@@ -116,12 +116,12 @@ namespace Visitz.ViewModels
 				// by reassigning its previous value
 				return;
 
+			SetDraftInfo();
+
 			int length = e.NewTextValue?.Length ?? 0;
 
 			if (length > 0 && !NoteDraft.IsManaged)
 				await Realm.WriteAsync(() => Realm.Add(NoteDraft));
-
-			SetDraftInfo();
 
 			if (TextIsInvalid(e))
             {


### PR DESCRIPTION
[STRY0031610 - Defect: Using auto-type suggestions in note entry after fresh app launch crashes the app](https://bcsocialsector.service-now.com/rm_story.do?sys_id=73dae015873ece943b837446dabb35d3&sysparm_view=&sysparm_time=1718403731193)