### PR TITLE
Only apply CaseloadItem if it's valid

### DIFF
--- a/visitz/Visitz/Views/Caseload/CaseloadItemView.xaml.cs
+++ b/visitz/Visitz/Views/Caseload/CaseloadItemView.xaml.cs
@@ -27,7 +27,7 @@ public partial class CaseloadItemView : ContentView
     {
         base.OnBindingContextChanged();
 
-        if (BindingContext is CaseloadItem item)
+        if (BindingContext is CaseloadItem item && item.IsValid)
 			ApplyCaseloadItem(item);
     }
 


### PR DESCRIPTION
Fixes a crashing issue if the Caseload list is cleared before the view is destroyed.