### PR TITLE
New/limit taken photo filesize

### DIFF
--- a/visitz/Visitz/Extensions/StreamImageExtensions.cs
+++ b/visitz/Visitz/Extensions/StreamImageExtensions.cs
@@ -5,9 +5,13 @@ namespace Visitz.Extensions;
 
 public static class StreamImageExtensions
 {
-	public static IImage MakeThumbnail(this Stream stream, float maxWidthOrHeight, bool disposeStream = false)
+	public static IImage MakeThumbnail(
+		this Stream stream,
+		float maxWidthOrHeight,
+		ImageFormat imageFormat = ImageFormat.Jpeg,
+		bool disposeStream = false)
 	{
 		stream.Seek(0, SeekOrigin.Begin);
-		return PlatformImage.FromStream(stream).Downsize(maxWidthOrHeight, disposeStream);
+		return PlatformImage.FromStream(stream, imageFormat).Downsize(maxWidthOrHeight, disposeStream);
 	}
 }

--- a/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
@@ -11,8 +11,6 @@ namespace Visitz.Views.Entity.Attachments;
 
 internal partial class AttachmentsViewModel : VisitzViewModel, ICaseloadItemHolder
 {
-	public static readonly float ThumbnailSize = 200.0f;
-
 	[ObservableProperty]
 	public CaseloadItem caseloadItem;
 

--- a/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
@@ -11,7 +11,7 @@ namespace Visitz.Views.Entity.Attachments;
 
 internal partial class AttachmentsViewModel : VisitzViewModel, ICaseloadItemHolder
 {
-	public static readonly float ThumbnailSize = 100.0f;
+	public static readonly float ThumbnailSize = 200.0f;
 
 	[ObservableProperty]
 	public CaseloadItem caseloadItem;

--- a/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
@@ -1,6 +1,5 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using Realms;
-using Visitz.Extensions;
 using Visitz.Storage;
 using Visitz.Views.BaseClasses;
 using VisitzModel.Extensions;
@@ -32,10 +31,7 @@ internal partial class AttachmentsViewModel : VisitzViewModel, ICaseloadItemHold
 		await using Stream stream = await fileResult.OpenReadAsync();
 
 		if (Attachment.AllowedImageTypes.Contains(extension.ToLowerInvariant()))
-		{
-			byte[] thumbnail = await stream.MakeThumbnail(ThumbnailSize).AsBytesAsync(ImageFormat.Jpeg);
-			await AttachmentDraft.SaveNewPhoto(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream, thumbnail);
-		}
+			await AttachmentDraft.SaveNewPhoto(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream);
 		else
 			await AttachmentDraft.SaveNewFile(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream);
 	}

--- a/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
@@ -32,11 +32,13 @@ internal partial class AttachmentsViewModel : VisitzViewModel, ICaseloadItemHold
 	{
 		string extension = fileResult.FileName.GetFileExtension();
 		await using Stream stream = await fileResult.OpenReadAsync();
-		byte[] thumbnail = null;
 
 		if (Attachment.AllowedImageTypes.Contains(extension.ToLowerInvariant()))
-			thumbnail = await stream.MakeThumbnail(ThumbnailSize).AsBytesAsync(ImageFormat.Jpeg);
-
-		await AttachmentDraft.SaveNewFile(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream, thumbnail);
+		{
+			byte[] thumbnail = await stream.MakeThumbnail(ThumbnailSize).AsBytesAsync(ImageFormat.Jpeg);
+			await AttachmentDraft.SaveNewPhoto(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream, thumbnail);
+		}
+		else
+			await AttachmentDraft.SaveNewFile(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream);
 	}
 }

--- a/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
@@ -37,6 +37,6 @@ internal partial class AttachmentsViewModel : VisitzViewModel, ICaseloadItemHold
 		if (Attachment.AllowedImageTypes.Contains(extension.ToLowerInvariant()))
 			thumbnail = await stream.MakeThumbnail(ThumbnailSize).AsBytesAsync(ImageFormat.Jpeg);
 
-		await AttachmentDraft.SaveNew(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream, thumbnail);
+		await AttachmentDraft.SaveNewFile(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream, thumbnail);
 	}
 }

--- a/visitz/Visitz/Views/Entity/Attachments/TakePhotoView.xaml.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/TakePhotoView.xaml.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Maui.Views;
 using Visitz.Animations;
+using Visitz.Extensions;
 using Visitz.Resources.Localization;
 using Visitz.Views.BaseClasses;
 using VisitzModel;
@@ -92,6 +93,7 @@ public partial class TakePhotoView : ViewModelContentView, ICaseloadItemHolder
 		}
 		catch (Exception ex)
 		{
+			await Navigator.CurrentOpenPage.DisplayErrorAlert(ex);
 			ConsoleTrace.TraceMethod(this, ex);
 		}
 	}

--- a/visitz/Visitz/Views/Entity/Attachments/TakePhotoViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/TakePhotoViewModel.cs
@@ -3,7 +3,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Realms;
 using System.Text;
-using Visitz.Extensions;
 using Visitz.Storage;
 using Visitz.Views.BaseClasses;
 using VisitzModel.Models;
@@ -120,10 +119,9 @@ internal partial class TakePhotoViewModel(ICameraProvider cameraProvider) : Visi
 
 		try
 		{
-			byte[] thumbnailBytes = await stream.MakeThumbnail(AttachmentsViewModel.ThumbnailSize).AsBytesAsync(ImageFormat.Jpeg);
 			string filename = attachmentFiler.MakeFilename(PictureFilenamePrepend, PictureFiletype);
 
-			await AttachmentDraft.SaveNewPhoto(attachmentFiler, AttachmentsRealm, filename, stream, thumbnailBytes);
+			await AttachmentDraft.SaveNewPhoto(attachmentFiler, AttachmentsRealm, filename, stream);
 		}
 		finally
 		{

--- a/visitz/Visitz/Views/Entity/Attachments/TakePhotoViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/TakePhotoViewModel.cs
@@ -123,7 +123,7 @@ internal partial class TakePhotoViewModel(ICameraProvider cameraProvider) : Visi
 			byte[] thumbnailBytes = await stream.MakeThumbnail(AttachmentsViewModel.ThumbnailSize).AsBytesAsync(ImageFormat.Jpeg);
 			string filename = attachmentFiler.MakeFilename(PictureFilenamePrepend, PictureFiletype);
 
-			await AttachmentDraft.SaveNew(attachmentFiler, AttachmentsRealm, filename, stream, thumbnailBytes);
+			await AttachmentDraft.SaveNewPhoto(attachmentFiler, AttachmentsRealm, filename, stream, thumbnailBytes);
 		}
 		finally
 		{

--- a/visitz/VisitzModel/Extensions/StreamExtensions.cs
+++ b/visitz/VisitzModel/Extensions/StreamExtensions.cs
@@ -1,0 +1,14 @@
+namespace VisitzModel.Extensions;
+
+public static class StreamExtensions
+{
+	public static async Task<byte[]> AsBytesAsync(this Stream stream)
+	{
+		byte[] bytesOut = new byte[stream.Length];
+
+		stream.Seek(0, SeekOrigin.Begin);
+		await stream.ReadAsync(bytesOut.AsMemory());
+
+		return bytesOut;
+	}
+}

--- a/visitz/VisitzModel/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Imaging/ImageProcessor.cs
@@ -4,10 +4,13 @@ public partial class ImageProcessor(Stream imageBytes)
 {
 	Stream ImageBytes { get; } = imageBytes;
 
-	public Task<Stream> DownsizeByFilesize(int bytesLength)
+	public Task<Stream> DownsizeByFilesize(int desiredMaxBytes)
 	{
+		if (ImageBytes.Length <= desiredMaxBytes)
+			return Task.FromResult(ImageBytes);
+
 		Task<Stream> task = default;
-		DownsizeByFilesize(ref task, bytesLength);
+		DownsizeByFilesize(ref task, desiredMaxBytes);
 		return task;
 	}
 

--- a/visitz/VisitzModel/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Imaging/ImageProcessor.cs
@@ -24,7 +24,7 @@ public partial class ImageProcessor(Stream imageBytes)
 		do
 		{
 			Task<Stream> task = default;
-			DownsizeByFilesize(ref task, desiredMaxBytes);
+			DownsizeByFilesize(ref task, (int)(desiredMaxBytes * factor));
 			streamOut = await task;
 
 			factor *= ReductionFactor;

--- a/visitz/VisitzModel/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Imaging/ImageProcessor.cs
@@ -6,7 +6,7 @@ public partial class ImageProcessor(Stream imageBytes)
 
 	static readonly float InitialFactor = 1.0f;
 
-	static readonly float ReductionFactor = 0.9f;
+	static readonly float ReductionFactor = 0.8f;
 
 	static readonly int FilesizeDownsizeLoopLimit = 25;
 

--- a/visitz/VisitzModel/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Imaging/ImageProcessor.cs
@@ -2,16 +2,43 @@ namespace VisitzModel.Imaging;
 
 public partial class ImageProcessor(Stream imageBytes)
 {
+	static readonly string MaxLoopsError = "Reached loop limit ({0}) when downsizing image ({1} bytes)";
+
+	static readonly float InitialFactor = 1.0f;
+
+	static readonly float ReductionFactor = 0.9f;
+
+	static readonly int FilesizeDownsizeLoopLimit = 25;
+
 	Stream ImageBytes { get; } = imageBytes;
 
-	public Task<Stream> DownsizeByFilesize(int desiredMaxBytes)
+	public async Task<Stream> DownsizeByFilesize(int desiredMaxBytes)
 	{
 		if (ImageBytes.Length <= desiredMaxBytes)
-			return Task.FromResult(ImageBytes);
+			return ImageBytes;
 
-		Task<Stream> task = default;
-		DownsizeByFilesize(ref task, desiredMaxBytes);
-		return task;
+		Stream streamOut;
+		float factor = InitialFactor;
+		int loopCount = 0;
+
+		do
+		{
+			Task<Stream> task = default;
+			DownsizeByFilesize(ref task, desiredMaxBytes);
+			streamOut = await task;
+
+			factor *= ReductionFactor;
+			loopCount++;
+
+			if (loopCount >= FilesizeDownsizeLoopLimit)
+			{
+				var error = string.Format(MaxLoopsError, FilesizeDownsizeLoopLimit, streamOut.Length);
+				throw new InvalidOperationException(error);
+			}
+
+		} while (streamOut.Length > desiredMaxBytes);
+
+		return streamOut;
 	}
 
 	public Task<Stream> Downsize(int maxWidthOrHeight)

--- a/visitz/VisitzModel/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Imaging/ImageProcessor.cs
@@ -1,0 +1,24 @@
+namespace VisitzModel.Imaging;
+
+public partial class ImageProcessor(Stream imageBytes)
+{
+	Stream ImageBytes { get; } = imageBytes;
+
+	public Task<Stream> DownsizeByFilesize(int bytesLength)
+	{
+		Task<Stream> task = default;
+		DownsizeByFilesize(ref task, bytesLength);
+		return task;
+	}
+
+	public Task<Stream> Downsize(int maxWidthOrHeight)
+	{
+		Task<Stream> task = default;
+		Downsize(ref task, maxWidthOrHeight);
+		return task;
+	}
+
+	partial void DownsizeByFilesize(ref Task<Stream> downsizeImageTask, int bytesLength);
+
+	partial void Downsize(ref Task<Stream> downsizeImageTask, int maxWidthOrHeight);
+}

--- a/visitz/VisitzModel/Models/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachment.cs
@@ -9,7 +9,7 @@ namespace VisitzModel.Models;
 public partial class Attachment : IRealmObject, IRecordInfo
 {
 	public static readonly int MaxFilesize = 5 * Sizes.MB;
-	public static readonly int ThumbnailSize = 200;
+	public static readonly int ThumbnailSize = 400;
 
 	public static readonly IEnumerable<string> AllowedImageTypes = [".jpg", ".jpeg"];
 	public static readonly IEnumerable<string> AllowedDocumentTypes = [".pdf"];

--- a/visitz/VisitzModel/Models/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachment.cs
@@ -9,6 +9,7 @@ namespace VisitzModel.Models;
 public partial class Attachment : IRealmObject, IRecordInfo
 {
 	public static readonly int MaxFilesize = 5 * Sizes.MB;
+	public static readonly int ThumbnailSize = 200;
 
 	public static readonly IEnumerable<string> AllowedImageTypes = [".jpg", ".jpeg"];
 	public static readonly IEnumerable<string> AllowedDocumentTypes = [".pdf"];

--- a/visitz/VisitzModel/Models/AttachmentDraft.cs
+++ b/visitz/VisitzModel/Models/AttachmentDraft.cs
@@ -46,10 +46,7 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 		byte[] thumbnail = null)
 	{
 		if (stream.Length > Attachment.MaxFilesize)
-		{
-			double tooLargeSize = stream.Length / (double)Sizes.MB;
-			throw new ArgumentException(GeneralStrings.FileTooLarge.Format(tooLargeSize), nameof(stream));
-		}
+			ThrowSizeError(stream);
 
 		string fullpath = await filer.SaveFileAsync(stream, filename.GetFileExtension());
 		var draft = MakeDraft(filer, filename, fullpath, thumbnail);
@@ -67,6 +64,12 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 		}
 
 		return draft;
+	}
+
+	static void ThrowSizeError(Stream stream)
+	{
+		double tooLargeSize = stream.Length / (double)Sizes.MB;
+		throw new ArgumentException(GeneralStrings.FileTooLarge.Format(tooLargeSize), nameof(stream));
 	}
 
 	static AttachmentDraft MakeDraft(AttachmentFiler filer, string filename, string relativePath, byte[] thumbnail)

--- a/visitz/VisitzModel/Models/AttachmentDraft.cs
+++ b/visitz/VisitzModel/Models/AttachmentDraft.cs
@@ -1,15 +1,13 @@
-using Microsoft.Maui.Graphics.Platform;
 using Realms;
 using VisitzApi.Models.Attachments;
 using VisitzModel.Extensions;
 using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Formats;
+using VisitzModel.Imaging;
 using VisitzModel.Models.Drafts;
 using VisitzModel.Models.EntityTypes;
 using VisitzModel.Resources.Localization;
 using VisitzModel.Storage.Filesystem;
-using VisitzModel.Utilities;
-using IImage = Microsoft.Maui.Graphics.IImage;
 
 namespace VisitzModel.Models;
 
@@ -45,14 +43,28 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 		AttachmentFiler filer,
 		Realm realm,
 		string filename,
-		Stream stream,
-		byte[] thumbnail = null)
+		Stream stream)
 	{
-		stream = LimitFilesizeByResize(stream, ImageFormat.Jpeg);
-		return await SaveNewFile(filer, realm, filename, stream, thumbnail);
+		var imgProc = new ImageProcessor(stream);
+
+		byte[] thumbnail = await (await imgProc.Downsize(Attachment.ThumbnailSize)).AsBytesAsync();
+
+		if (stream.Length > Attachment.MaxFilesize)
+			stream = await imgProc.DownsizeByFilesize(Attachment.MaxFilesize);
+
+		return await MakeAndSaveDraft(filer, realm, filename, stream, thumbnail);
 	}
 
 	public static async Task<AttachmentDraft> SaveNewFile(
+		AttachmentFiler filer,
+		Realm realm,
+		string filename,
+		Stream stream)
+	{
+		return await MakeAndSaveDraft(filer, realm, filename, stream);
+	}
+
+	static async Task<AttachmentDraft> MakeAndSaveDraft(
 		AttachmentFiler filer,
 		Realm realm,
 		string filename,
@@ -78,40 +90,6 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 		}
 
 		return draft;
-	}
-
-	static Stream LimitFilesizeByResize(Stream stream, ImageFormat imageFormat)
-	{
-		if (stream.Length <= Attachment.MaxFilesize)
-			return stream;
-
-		var (image, newWidth, newHeight) = GetNewDimensions(stream, imageFormat);
-
-		var downsizedImage = image.Downsize(Math.Max(newWidth, newHeight));
-
-		var downsizedStream = downsizedImage.AsStream(imageFormat);
-
-		ConsoleTrace.TraceMethod(typeof(AttachmentDraft),
-			$"Original size '{stream.Length}' ||| Resized size '{downsizedStream.Length}'");
-
-		return downsizedStream;
-	}
-
-	static (IImage Image, float NewWidth, float NewHeight) GetNewDimensions(Stream stream, ImageFormat imageFormat)
-	{
-		stream.Seek(0, SeekOrigin.Begin);
-
-		var image = PlatformImage.FromStream(stream, imageFormat);
-
-		var (newWidth, newHeight) = ResizeImageValues.ResizeByFileSize(
-			image.Width,
-			image.Height,
-			Attachment.MaxFilesize);
-
-		ConsoleTrace.TraceMethod(typeof(AttachmentDraft),
-			$"Original w,h ({image.Width},{image.Height}) ||| Resized w,h ({newWidth},{newHeight})");
-
-		return (image, newWidth, newHeight);
 	}
 
 	static void ThrowSizeError(Stream stream)

--- a/visitz/VisitzModel/Models/AttachmentDraft.cs
+++ b/visitz/VisitzModel/Models/AttachmentDraft.cs
@@ -1,3 +1,4 @@
+using Microsoft.Maui.Graphics.Platform;
 using Realms;
 using VisitzApi.Models.Attachments;
 using VisitzModel.Extensions;
@@ -7,6 +8,8 @@ using VisitzModel.Models.Drafts;
 using VisitzModel.Models.EntityTypes;
 using VisitzModel.Resources.Localization;
 using VisitzModel.Storage.Filesystem;
+using VisitzModel.Utilities;
+using IImage = Microsoft.Maui.Graphics.IImage;
 
 namespace VisitzModel.Models;
 
@@ -45,6 +48,7 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 		Stream stream,
 		byte[] thumbnail = null)
 	{
+		stream = LimitFilesizeByResize(stream, ImageFormat.Jpeg);
 		return await SaveNewFile(filer, realm, filename, stream, thumbnail);
 	}
 
@@ -74,6 +78,40 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 		}
 
 		return draft;
+	}
+
+	static Stream LimitFilesizeByResize(Stream stream, ImageFormat imageFormat)
+	{
+		if (stream.Length <= Attachment.MaxFilesize)
+			return stream;
+
+		var (image, newWidth, newHeight) = GetNewDimensions(stream, imageFormat);
+
+		var downsizedImage = image.Downsize(Math.Max(newWidth, newHeight));
+
+		var downsizedStream = downsizedImage.AsStream(imageFormat);
+
+		ConsoleTrace.TraceMethod(typeof(AttachmentDraft),
+			$"Original size '{stream.Length}' ||| Resized size '{downsizedStream.Length}'");
+
+		return downsizedStream;
+	}
+
+	static (IImage Image, float NewWidth, float NewHeight) GetNewDimensions(Stream stream, ImageFormat imageFormat)
+	{
+		stream.Seek(0, SeekOrigin.Begin);
+
+		var image = PlatformImage.FromStream(stream, imageFormat);
+
+		var (newWidth, newHeight) = ResizeImageValues.ResizeByFileSize(
+			image.Width,
+			image.Height,
+			Attachment.MaxFilesize);
+
+		ConsoleTrace.TraceMethod(typeof(AttachmentDraft),
+			$"Original w,h ({image.Width},{image.Height}) ||| Resized w,h ({newWidth},{newHeight})");
+
+		return (image, newWidth, newHeight);
 	}
 
 	static void ThrowSizeError(Stream stream)

--- a/visitz/VisitzModel/Models/AttachmentDraft.cs
+++ b/visitz/VisitzModel/Models/AttachmentDraft.cs
@@ -38,7 +38,17 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 
 	public Attachment Attachment { get; set; }
 
-	public static async Task<AttachmentDraft> SaveNew(
+	public static async Task<AttachmentDraft> SaveNewPhoto(
+		AttachmentFiler filer,
+		Realm realm,
+		string filename,
+		Stream stream,
+		byte[] thumbnail = null)
+	{
+		return await SaveNewFile(filer, realm, filename, stream, thumbnail);
+	}
+
+	public static async Task<AttachmentDraft> SaveNewFile(
 		AttachmentFiler filer,
 		Realm realm,
 		string filename,

--- a/visitz/VisitzModel/Platforms/Windows/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Platforms/Windows/Imaging/ImageProcessor.cs
@@ -1,0 +1,71 @@
+using VisitzModel.Utilities;
+using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Processing;
+using Image = SixLabors.ImageSharp.Image;
+
+namespace VisitzModel.Imaging;
+
+public partial class ImageProcessor
+{
+	partial void DownsizeByFilesize(ref Task<Stream> downsizeImageTask, int bytesLength)
+	{
+		downsizeImageTask = bytesLength >= ImageBytes.Length
+			? Task.FromResult(ImageBytes)
+			: Task.Run(async () =>
+			{
+				var image = await ConvertToImageAsync(ImageBytes);
+				var newMax = ResizeImageValues.MaxNewDimensionByFileSize(image.Width, image.Height, bytesLength);
+
+				ResizeImage(image, (int)newMax);
+				return await ConvertToStreamAsync(image);
+			});
+	}
+
+	partial void Downsize(ref Task<Stream> downsizeImageTask, int maxWidthOrHeight)
+	{
+		downsizeImageTask = Task.Run(async () =>
+		{
+			var image = await ConvertToImageAsync(ImageBytes);
+
+			if (Math.Max(image.Width, image.Height) > maxWidthOrHeight)
+			{
+				ResizeImage(image, maxWidthOrHeight);
+				return await ConvertToStreamAsync(image);
+			}
+			else
+				return ImageBytes;
+		});
+	}
+
+	static async Task<Image> ConvertToImageAsync(Stream imageBytes, CancellationToken? token = null)
+	{
+		return await Image.LoadAsync(imageBytes, token ?? CancellationToken.None);
+	}
+
+	/// <summary>
+	/// .NET MAUI 8.x's Microsoft.Maui.Graphics.IImage.Downsize() functionality isn't implemented on Windows so we
+	/// need to use an external library for it.
+	/// </summary>
+	/// <param name="image"></param>
+	/// <param name="maxWidthOrHeight"></param>
+	static void ResizeImage(Image image, int maxWidthOrHeight)
+	{
+		image.Mutate(i =>
+		{
+			i.Resize(new ResizeOptions
+			{
+				Size = new SixLabors.ImageSharp.Size(maxWidthOrHeight),
+				Mode = SixLabors.ImageSharp.Processing.ResizeMode.Max,
+			});
+		});
+	}
+
+	static async Task<Stream> ConvertToStreamAsync(Image image)
+	{
+		MemoryStream outStream = new();
+		await image.SaveAsJpegAsync(outStream);
+
+		outStream.Seek(0, SeekOrigin.Begin);
+		return outStream;
+	}
+}

--- a/visitz/VisitzModel/Platforms/iOS/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Platforms/iOS/Imaging/ImageProcessor.cs
@@ -6,14 +6,6 @@ namespace VisitzModel.Imaging;
 
 public partial class ImageProcessor
 {
-	static readonly string MaxLoopsError = "Reached loop limit ({0}) when downsizing image ({1} bytes)";
-
-	static readonly float InitialFactor = 1.0f;
-
-	static readonly float ReductionFactor = 0.9f;
-
-	static readonly int FilesizeDownsizeLoopLimit = 25;
-
 	partial void DownsizeByFilesize(ref Task<Stream> downsizeImageTask, int bytesLength)
 	{
 		downsizeImageTask = bytesLength >= ImageBytes.Length
@@ -21,29 +13,11 @@ public partial class ImageProcessor
 			: Task.Run(() =>
 			{
 				ImageBytes.Seek(0, SeekOrigin.Begin);
+
 				var image = PlatformImage.FromStream(ImageBytes, ImageFormat.Jpeg);
 				var newMax = ResizeImageValues.MaxNewDimensionByFileSize(image.Width, image.Height, bytesLength);
 
-				Stream streamOut;
-				float factor = InitialFactor;
-				int loopCount = 0;
-
-				do
-				{
-					streamOut = image.Downsize(newMax * factor).AsStream();
-					
-					factor *= ReductionFactor;
-					loopCount++;
-
-					if (loopCount >= FilesizeDownsizeLoopLimit)
-					{
-						var error = MaxLoopsError.Format(FilesizeDownsizeLoopLimit, streamOut.Length);
-						throw new InvalidOperationException(error);
-					}
-
-				} while (streamOut.Length > bytesLength);
-
-				return streamOut;
+				return image.Downsize(newMax).AsStream();
 			});
 	}
 

--- a/visitz/VisitzModel/Platforms/iOS/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Platforms/iOS/Imaging/ImageProcessor.cs
@@ -1,0 +1,33 @@
+using Microsoft.Maui.Graphics.Platform;
+using VisitzModel.Utilities;
+
+namespace VisitzModel.Imaging;
+
+public partial class ImageProcessor
+{
+	partial void DownsizeByFilesize(ref Task<Stream> downsizeImageTask, int bytesLength)
+	{
+		downsizeImageTask = bytesLength >= ImageBytes.Length
+			? Task.FromResult(ImageBytes)
+			: Task.Run(() =>
+			{
+				var image = PlatformImage.FromStream(ImageBytes, ImageFormat.Jpeg);
+				var newMax = ResizeImageValues.MaxNewDimensionByFileSize(image.Width, image.Height, bytesLength);
+
+				return image.Downsize(newMax).AsStream();
+			});
+	}
+
+	partial void Downsize(ref Task<Stream> downsizeImageTask, int maxWidthOrHeight)
+	{
+		downsizeImageTask = Task.Run(() =>
+		{
+			var image = PlatformImage.FromStream(ImageBytes, ImageFormat.Jpeg);
+			var maxImageDimension = Math.Max(image.Width, image.Height);
+
+			return maxWidthOrHeight < maxImageDimension
+				? image.Downsize(maxWidthOrHeight).AsStream()
+				: ImageBytes;
+		});
+	}
+}

--- a/visitz/VisitzModel/Platforms/iOS/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Platforms/iOS/Imaging/ImageProcessor.cs
@@ -1,20 +1,49 @@
 using Microsoft.Maui.Graphics.Platform;
+using VisitzModel.Extensions;
 using VisitzModel.Utilities;
 
 namespace VisitzModel.Imaging;
 
 public partial class ImageProcessor
 {
+	static readonly string MaxLoopsError = "Reached loop limit ({0}) when downsizing image ({1} bytes)";
+
+	static readonly float InitialFactor = 1.0f;
+
+	static readonly float ReductionFactor = 0.9f;
+
+	static readonly int FilesizeDownsizeLoopLimit = 25;
+
 	partial void DownsizeByFilesize(ref Task<Stream> downsizeImageTask, int bytesLength)
 	{
 		downsizeImageTask = bytesLength >= ImageBytes.Length
 			? Task.FromResult(ImageBytes)
 			: Task.Run(() =>
 			{
+				ImageBytes.Seek(0, SeekOrigin.Begin);
 				var image = PlatformImage.FromStream(ImageBytes, ImageFormat.Jpeg);
 				var newMax = ResizeImageValues.MaxNewDimensionByFileSize(image.Width, image.Height, bytesLength);
 
-				return image.Downsize(newMax).AsStream();
+				Stream streamOut;
+				float factor = InitialFactor;
+				int loopCount = 0;
+
+				do
+				{
+					streamOut = image.Downsize(newMax * factor).AsStream();
+					
+					factor *= ReductionFactor;
+					loopCount++;
+
+					if (loopCount >= FilesizeDownsizeLoopLimit)
+					{
+						var error = MaxLoopsError.Format(FilesizeDownsizeLoopLimit, streamOut.Length);
+						throw new InvalidOperationException(error);
+					}
+
+				} while (streamOut.Length > bytesLength);
+
+				return streamOut;
 			});
 	}
 

--- a/visitz/VisitzModel/Utilities/ResizeImageValues.cs
+++ b/visitz/VisitzModel/Utilities/ResizeImageValues.cs
@@ -2,11 +2,20 @@ namespace VisitzModel.Utilities;
 
 internal static class ResizeImageValues
 {
-	public static (float newWidth, float newHeight) ResizeByFileSize(
+	public static (float newWidth, float newHeight) NewDimensionsByFileSize(
 		float currentWidth,
 		float currentHeight,
 		long desiredFileSize)
 	{
 		return (desiredFileSize / currentHeight, desiredFileSize / currentWidth);
+	}
+
+	public static float MaxNewDimensionByFileSize(
+		float currentWidth,
+		float currentHeight,
+		long desiredFileSize)
+	{
+		var (newWidth, newHeight) = NewDimensionsByFileSize(currentWidth, currentHeight, desiredFileSize);
+		return Math.Max(newWidth, newHeight);
 	}
 }

--- a/visitz/VisitzModel/Utilities/ResizeImageValues.cs
+++ b/visitz/VisitzModel/Utilities/ResizeImageValues.cs
@@ -1,0 +1,12 @@
+namespace VisitzModel.Utilities;
+
+internal static class ResizeImageValues
+{
+	public static (float newWidth, float newHeight) ResizeByFileSize(
+		float currentWidth,
+		float currentHeight,
+		long desiredFileSize)
+	{
+		return (desiredFileSize / currentHeight, desiredFileSize / currentWidth);
+	}
+}

--- a/visitz/VisitzModel/VisitzModel.csproj
+++ b/visitz/VisitzModel/VisitzModel.csproj
@@ -28,6 +28,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="SharpSource" Version="1.24.0" PrivateAssets="All" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
[STRY0032227 - Reduce image file size to 5MB if they're larger](https://bcsocialsector.service-now.com/rm_story.do?sys_id=5c0d5204dbef8a50d8054b491396193e&sysparm_view=&sysparm_time=1726507339561)