### PR TITLE
Add visitz-api hyperlink to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ Internally, the app is referred to as **Visitz**. You can find the app code and 
 
 GitHub Actions are used to make release builds for desired platform targets. Refer to [this repository's workflows README](.github/workflows/README.md) for detailed information and instructions on how to run them.
 
+## API
+
+Implementation of the middleware API the app connects to can be found at [visitz-api](https://github.com/bcgov-isd/visitz-api).
+
 ## Licence
 
 Copyright 2019 Province of British Columbia


### PR DESCRIPTION
Adding a hyperlink to the README so the middleware API implementation is more easily discoverable.