### PR TITLE
Text change on logout popup

### DIFF
--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -880,7 +880,7 @@ namespace Visitz.Resources.Localization {
         /// <summary>
         ///   Looks up a localized string similar to Cached ICM data on this device will be cleared and you will need to log in again before using any ICM features over the internet.
         ///
-        ///Logging out won&apos;t affect your unpublished notes..
+        ///Logging out won&apos;t affect your unpublished drafts..
         /// </summary>
         public static string LogoutAndClearDataDesc {
             get {

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -192,7 +192,7 @@
   <data name="LogoutAndClearDataDesc" xml:space="preserve">
     <value>Cached ICM data on this device will be cleared and you will need to log in again before using any ICM features over the internet.
 
-Logging out won't affect your unpublished notes.</value>
+Logging out won't affect your unpublished drafts.</value>
   </data>
   <data name="YouAreAuthorized" xml:space="preserve">
     <value>You are authorized to use MCFD Mobility.</value>


### PR DESCRIPTION
[STRY0033173: Update text references from "notes" to "drafts"](https://bcsocialsector.service-now.com/rm_story.do?sys_id=43d40bb793d4de50e09fb1584dba1025&sysparm_view=&sysparm_time=1726689314983)