### PR TITLE
Label margin updated

### DIFF
--- a/visitz/Visitz/Views/Entity/FamilyMembers/ContactItemView.xaml
+++ b/visitz/Visitz/Views/Entity/FamilyMembers/ContactItemView.xaml
@@ -30,6 +30,7 @@
                 FontSize="17"/>
 
             <tagview:TagView Padding="8,3">
+            <tagview:TagView Padding="8,0">
                 <tagview:TagView.Behaviors>
                     <tagBehaviors:ContactRelationshipTagBehavior />
                 </tagview:TagView.Behaviors>

--- a/visitz/Visitz/Views/Entity/FamilyMembers/ContactItemView.xaml
+++ b/visitz/Visitz/Views/Entity/FamilyMembers/ContactItemView.xaml
@@ -29,7 +29,6 @@
                 FontFamily="BCSansBold"
                 FontSize="17"/>
 
-            <tagview:TagView Padding="8,3">
             <tagview:TagView Padding="8,0">
                 <tagview:TagView.Behaviors>
                     <tagBehaviors:ContactRelationshipTagBehavior />


### PR DESCRIPTION
[STRY0031018: Fixed family members label not displaying full text issue](https://bcsocialsector.service-now.com/rm_story.do?sys_id=3f706a80876602903b837446dabb3566&sysparm_view=&sysparm_time=1727195867279)