### PR TITLE
Radio button not working in dark mode

### DIFF
--- a/visitz/Visitz/Platforms/iOS/Info.plist
+++ b/visitz/Visitz/Platforms/iOS/Info.plist
@@ -47,5 +47,7 @@
 	<false/>
 	<key>NSCameraUsageDescription</key>
 	<string>Camera used for taking pictures to add to records as attachments.</string>
+	<key>UIUserInterfaceStyle</key> <!-- For light mode only -->
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
[STRY0032658: Fix radio button not working in dark mode in iPad](https://bcsocialsector.service-now.com/rm_story.do?sys_id=e2e3cf7edbb70ed0d8054b4913961975&sysparm_view=&sysparm_time=1727286459125)