### PR TITLE
Fixed rename publish photo crash issue

### DIFF
--- a/visitz/Visitz/Services/SubmitAttachmentService.cs
+++ b/visitz/Visitz/Services/SubmitAttachmentService.cs
@@ -8,12 +8,12 @@ internal class SubmitAttachmentService(Vpi vpi) : VisitzApiService(vpi)
 {
 	public static string MakeId(SubmitAttachmentEntity entity)
 	{
-		return MakeId(entity.EntityNumber, entity.FileName);
+		return MakeId(entity.EntityNumber, entity.AttachmentId);
 	}
 
-	public static string MakeId(string entityNumber, string attachmentName)
+	public static string MakeId(string entityNumber, string attachmentId)
 	{
-		return $"{nameof(SubmitAttachmentService)}-{entityNumber}-{attachmentName}";
+		return $"{nameof(SubmitAttachmentService)}-{entityNumber}-{attachmentId}";
 	}
 
 	public static StartServiceMessage MakeStartMessage(SubmitAttachmentEntity submitEntity)
@@ -21,7 +21,7 @@ internal class SubmitAttachmentService(Vpi vpi) : VisitzApiService(vpi)
 		return new()
 		{
 			Payload = submitEntity,
-			ServiceId = MakeId(submitEntity.EntityNumber, submitEntity.FileName),
+			ServiceId = MakeId(submitEntity.EntityNumber, submitEntity.AttachmentId),
 			ServiceType = typeof(SubmitAttachmentService),
 		};
 	}

--- a/visitz/Visitz/Views/Entity/Attachments/PhotoDetailsView.xaml.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/PhotoDetailsView.xaml.cs
@@ -34,7 +34,7 @@ public partial class PhotoDetailsView : ViewModelContentView, ICaseloadItemHolde
 
 		if (attachment.Draft is AttachmentDraft draft)
 		{
-			string id = SubmitAttachmentService.MakeId(draft.RelatedEntityId, attachment.Filename);
+			string id = SubmitAttachmentService.MakeId(draft.RelatedEntityId, attachment.AttachmentId);
 			WeakReferenceMessenger.Default.Register(this, id);
 		}
 	}

--- a/visitz/Visitz/Views/Entity/Attachments/PhotoDetailsView.xaml.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/PhotoDetailsView.xaml.cs
@@ -34,7 +34,7 @@ public partial class PhotoDetailsView : ViewModelContentView, ICaseloadItemHolde
 
 		if (attachment.Draft is AttachmentDraft draft)
 		{
-			string id = SubmitAttachmentService.MakeId(draft.RelatedEntityId, attachment.AttachmentId);
+			string id = SubmitAttachmentService.MakeId(draft.RelatedEntityId, attachment.Id);
 			WeakReferenceMessenger.Default.Register(this, id);
 		}
 	}

--- a/visitz/VisitzApi/Models/Attachments/SubmitAttachmentEntity.cs
+++ b/visitz/VisitzApi/Models/Attachments/SubmitAttachmentEntity.cs
@@ -4,6 +4,7 @@ namespace VisitzApi.Models.Attachments;
 
 public class SubmitAttachmentEntity
 {
+	public string AttachmentId { get; set; }
 	public string EntityNumber { get; set; }
 	public string EntityType { get; set; }
 	public string CaseType { get; set; }
@@ -16,7 +17,6 @@ public class SubmitAttachmentEntity
 	public Section13Payload Section13 { get; set; }
 	public CfaDetailsPayload CfaDetails { get; set; }
 	public AttachmentBlock Attachment { get; set; }
-	public string AttachmentId { get; set; }
 
 	public class AttachmentBlock
 	{

--- a/visitz/VisitzApi/Models/Attachments/SubmitAttachmentEntity.cs
+++ b/visitz/VisitzApi/Models/Attachments/SubmitAttachmentEntity.cs
@@ -16,6 +16,7 @@ public class SubmitAttachmentEntity
 	public Section13Payload Section13 { get; set; }
 	public CfaDetailsPayload CfaDetails { get; set; }
 	public AttachmentBlock Attachment { get; set; }
+	public string AttachmentId { get; set; }
 
 	public class AttachmentBlock
 	{

--- a/visitz/VisitzModel/Models/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachment.cs
@@ -14,6 +14,8 @@ public partial class Attachment : IRealmObject, IRecordInfo
 	public static readonly IEnumerable<string> AllowedImageTypes = [".jpg", ".jpeg"];
 	public static readonly IEnumerable<string> AllowedDocumentTypes = [".pdf"];
 
+	public string AttachmentId {get; set;} = Guid.NewGuid().ToString();
+
 	public string RelatedEntityId { get; set; }
 
 	private int RelatedEntityTypeInt { get; set; } = (int)EntityType.Unknown;

--- a/visitz/VisitzModel/Models/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachment.cs
@@ -14,7 +14,8 @@ public partial class Attachment : IRealmObject, IRecordInfo
 	public static readonly IEnumerable<string> AllowedImageTypes = [".jpg", ".jpeg"];
 	public static readonly IEnumerable<string> AllowedDocumentTypes = [".pdf"];
 
-	public string AttachmentId {get; set;} = Guid.NewGuid().ToString();
+	[PrimaryKey]
+	public string Id {get; set;} = Guid.NewGuid().ToString();
 
 	public string RelatedEntityId { get; set; }
 

--- a/visitz/VisitzModel/Models/AttachmentDraft.cs
+++ b/visitz/VisitzModel/Models/AttachmentDraft.cs
@@ -147,6 +147,7 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 			CaseType = RelatedEntitySubtype.GetDisplayString(),
 			FormName = IcmFormNames.GenericDocument,
 			FileName = Attachment.Filename,
+			AttachmentId = Attachment.AttachmentId,
 			FormDescription = "",
 			FormCategory = "",
 			Section13Exists = "",

--- a/visitz/VisitzModel/Models/AttachmentDraft.cs
+++ b/visitz/VisitzModel/Models/AttachmentDraft.cs
@@ -142,12 +142,12 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 
 		return new()
 		{
+			AttachmentId = Attachment.AttachmentId,
 			EntityNumber = RelatedEntityId,
 			EntityType = RelatedEntityType.GetDisplayString(),
 			CaseType = RelatedEntitySubtype.GetDisplayString(),
 			FormName = IcmFormNames.GenericDocument,
 			FileName = Attachment.Filename,
-			AttachmentId = Attachment.AttachmentId,
 			FormDescription = "",
 			FormCategory = "",
 			Section13Exists = "",

--- a/visitz/VisitzModel/Models/AttachmentDraft.cs
+++ b/visitz/VisitzModel/Models/AttachmentDraft.cs
@@ -142,7 +142,7 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 
 		return new()
 		{
-			AttachmentId = Attachment.AttachmentId,
+			AttachmentId = Attachment.Id,
 			EntityNumber = RelatedEntityId,
 			EntityType = RelatedEntityType.GetDisplayString(),
 			CaseType = RelatedEntitySubtype.GetDisplayString(),


### PR DESCRIPTION
[STRY0034561: Fixed rename and then publish photo from detail view crashes the app issue](https://bcsocialsector.service-now.com/rm_story.do?sys_id=34c9fccd330e5e5084a805570e5c7b4d&sysparm_view=&sysparm_time=1732747724179)