### PR TITLE
Fixed photo crash issue

### DIFF
--- a/visitz/Visitz/Views/Entity/Attachments/TakePhotoView.xaml.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/TakePhotoView.xaml.cs
@@ -74,11 +74,6 @@ public partial class TakePhotoView : ViewModelContentView, ICaseloadItemHolder
         }
     }
 
-    private async Task CaptureImageAsync()
-    {
-        await Camera.CaptureImage(CancellationToken.None);
-    }
-
     private async Task AnimateSnapshotAsync()
     {
         SnapshotLayer.IsVisible = true;
@@ -136,8 +131,7 @@ public partial class TakePhotoView : ViewModelContentView, ICaseloadItemHolder
         {
             _ = AnimateSnapshotAsync();
             CameraRollButton.IsEnabled = false;
-            var captureTask = CaptureImageAsync();
-            await captureTask;
+            await Camera.CaptureImage(CancellationToken.None);
         }
         catch (Exception ex)
         {


### PR DESCRIPTION
[STRY0032191: Fixed rapidly taking photos crashes the app](https://bcsocialsector.service-now.com/rm_story.do?sys_id=5919bc22dbdb4e10d8054b491396193c&sysparm_view=&sysparm_time=1733336525417)