### PR TITLE
Workaround MAUI issue #22228 with Windows.Networking.Connectivity

### DIFF
--- a/visitz/Oidc/Network/NetworkHelper.cs
+++ b/visitz/Oidc/Network/NetworkHelper.cs
@@ -1,8 +1,20 @@
-﻿namespace Oidc.Network;
+namespace Oidc.Network;
+
+#if WINDOWS
+using Windows.Networking.Connectivity;
+#endif
 
 public static class NetworkHelper
 {
-    public static bool InternetAvailable => Connectivity.Current.NetworkAccess == NetworkAccess.Internet;
+    public static bool InternetAvailable =>
+#if WINDOWS
+        // WORKAROUND https://github.com/dotnet/maui/issues/22228#issuecomment-2118235512
+        // NetworkAccess reported incorrectly on Windows on VPN
+        NetworkInformation.GetInternetConnectionProfile().GetNetworkConnectivityLevel()
+        == NetworkConnectivityLevel.InternetAccess;
+#else
+        Connectivity.Current.NetworkAccess == NetworkAccess.Internet;
+#endif
 
     public static void AssertInternetAvailable(string messageIfUnavailable)
     {


### PR DESCRIPTION
[STRY0033864 - Fix online capabilities for Windows Mob App while the VPN is in use.](https://bcsocialsector.service-now.com/rm_story.do?sys_id=0a7b15bd47111a10e90c809a516d4348&sysparm_view=&sysparm_time=1736545175867)