### PR TITLE
attachments storage updated to remove caseloaditem

### DIFF
--- a/visitz/Visitz/Storage/VisitzFiles.cs
+++ b/visitz/Visitz/Storage/VisitzFiles.cs
@@ -12,6 +12,11 @@ internal static class VisitzFiles
 	public static async Task<AttachmentFiler> GetAsync(CaseloadItem caseloadItem, string keyName = null)
 	{
 		keyName ??= DefaultFilesKeyName;
-		return new AttachmentFiler(caseloadItem, await VisitzKey.GetKey(keyName, Aes256KeySize));
+		return new AttachmentFiler(
+			caseloadItem.EntityType,
+			caseloadItem.CaseIncidentNumber,
+			caseloadItem.KeyPlayer.FirstName,
+			caseloadItem.KeyPlayer.LastName,
+			await VisitzKey.GetKey(keyName, Aes256KeySize));
 	}
 }

--- a/visitz/Visitz/Storage/VisitzFiles.cs
+++ b/visitz/Visitz/Storage/VisitzFiles.cs
@@ -1,3 +1,4 @@
+using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Models;
 using VisitzModel.Storage;
 using VisitzModel.Storage.Filesystem;
@@ -13,7 +14,7 @@ internal static class VisitzFiles
 	{
 		keyName ??= DefaultFilesKeyName;
 		return new AttachmentFiler(
-			caseloadItem.EntityType,
+			caseloadItem.EntityType.ParseEntityType(),
 			caseloadItem.CaseIncidentNumber,
 			caseloadItem.KeyPlayer.FirstName,
 			caseloadItem.KeyPlayer.LastName,

--- a/visitz/Visitz/Storage/VisitzFiles.cs
+++ b/visitz/Visitz/Storage/VisitzFiles.cs
@@ -1,5 +1,6 @@
 using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Models;
+using VisitzModel.Models.EntityTypes;
 using VisitzModel.Storage;
 using VisitzModel.Storage.Filesystem;
 
@@ -10,14 +11,19 @@ internal static class VisitzFiles
 	static readonly string DefaultFilesKeyName = "DefaultFilesKey";
 	static readonly int Aes256KeySize = 32;
 
-	public static async Task<AttachmentFiler> GetAsync(CaseloadItem caseloadItem, string keyName = null)
+    public static async Task<AttachmentFiler> GetAsync(
+        EntityType entityType,
+        string caseIncidentNumber,
+        string firstName,
+        string lastName,
+        string keyName = null)
 	{
 		keyName ??= DefaultFilesKeyName;
 		return new AttachmentFiler(
-			caseloadItem.EntityType.ParseEntityType(),
-			caseloadItem.CaseIncidentNumber,
-			caseloadItem.KeyPlayer.FirstName,
-			caseloadItem.KeyPlayer.LastName,
+			entityType,
+			caseIncidentNumber,
+			firstName,
+			lastName,
 			await VisitzKey.GetKey(keyName, Aes256KeySize));
 	}
 }

--- a/visitz/Visitz/Views/Entity/Attachments/AttachmentsListViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/AttachmentsListViewModel.cs
@@ -9,6 +9,7 @@ using Visitz.Views.BaseClasses;
 using Visitz.Views.BaseClasses.Publishing;
 using Visitz.Views.Snackbar;
 using VisitzModel.Extensions;
+using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Interfaces;
 using VisitzModel.Models;
 using VisitzModel.Models.Attachments;
@@ -113,7 +114,11 @@ internal partial class AttachmentsListViewModel : VisitzViewModel, ICaseloadItem
 	{
 		var attachmentPublishVm = ServiceProvider.Current.GetService<AttachmentDraftPublishViewModel>();
 		attachmentPublishVm.AttachmentDraft = draft;
-		attachmentPublishVm.AttachmentFiler = await VisitzFiles.GetAsync(CaseloadItem);
+		attachmentPublishVm.AttachmentFiler = await VisitzFiles.GetAsync(
+			CaseloadItem.EntityType.ParseEntityType(),
+			CaseloadItem.CaseIncidentNumber,
+			CaseloadItem.KeyPlayer.FirstName,
+			CaseloadItem.KeyPlayer.LastName);
 
 		await Navigator.Navigation.PushModalAsync(new PublishPage(attachmentPublishVm));
 	}

--- a/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
@@ -33,8 +33,8 @@ internal partial class AttachmentsViewModel : VisitzViewModel, ICaseloadItemHold
 		await using Stream stream = await fileResult.OpenReadAsync();
 
 		if (Attachment.AllowedImageTypes.Contains(extension.ToLowerInvariant()))
-			await AttachmentDraft.SaveNewPhoto(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream);
+			await AttachmentDraft.SaveNewPhoto(CaseloadItem, attachmentFiler, AttachmentsRealm, fileResult.FileName, stream);
 		else
-			await AttachmentDraft.SaveNewFile(attachmentFiler, AttachmentsRealm, fileResult.FileName, stream);
+			await AttachmentDraft.SaveNewFile(CaseloadItem, attachmentFiler, AttachmentsRealm, fileResult.FileName, stream);
 	}
 }

--- a/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/AttachmentsViewModel.cs
@@ -3,6 +3,7 @@ using Realms;
 using Visitz.Storage;
 using Visitz.Views.BaseClasses;
 using VisitzModel.Extensions;
+using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Interfaces;
 using VisitzModel.Models;
 using VisitzModel.Models.Attachments;
@@ -24,7 +25,11 @@ internal partial class AttachmentsViewModel : VisitzViewModel, ICaseloadItemHold
 		base.Create();
 
 		AttachmentsRealm = await VisitzRealms.GetAttachmentDraftsRealmAsync();
-		attachmentFiler = await VisitzFiles.GetAsync(CaseloadItem);
+		attachmentFiler = await VisitzFiles.GetAsync(
+			CaseloadItem.EntityType.ParseEntityType(),
+			CaseloadItem.CaseIncidentNumber,
+			CaseloadItem.KeyPlayer.FirstName,
+			CaseloadItem.KeyPlayer.LastName);
 	}
 
 	public async Task SaveFile(FileResult fileResult)

--- a/visitz/Visitz/Views/Entity/Attachments/PhotoDetailsViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/PhotoDetailsViewModel.cs
@@ -6,6 +6,7 @@ using Visitz.Views.BaseClasses;
 using Visitz.Views.BaseClasses.Publishing;
 using Visitz.Views.Snackbar;
 using VisitzModel.Extensions;
+using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Interfaces;
 using VisitzModel.Models;
 using VisitzModel.Models.Attachments;
@@ -30,7 +31,11 @@ internal partial class PhotoDetailsViewModel : VisitzViewModel, ICaseloadItemHol
 	{
 		base.Create();
 
-		attachmentFiler = await VisitzFiles.GetAsync(CaseloadItem);
+		attachmentFiler = await VisitzFiles.GetAsync(
+			CaseloadItem.EntityType.ParseEntityType(),
+			CaseloadItem.CaseIncidentNumber,
+			CaseloadItem.KeyPlayer.FirstName,
+			CaseloadItem.KeyPlayer.LastName);
 
 		DetailImage = ImageSource.FromStream(GetPhoto);
 	}

--- a/visitz/Visitz/Views/Entity/Attachments/TakePhotoViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/TakePhotoViewModel.cs
@@ -123,7 +123,7 @@ internal partial class TakePhotoViewModel(ICameraProvider cameraProvider) : Visi
 		{
 			string filename = attachmentFiler.MakeFilename(PictureFilenamePrepend, PictureFiletype);
 
-			await AttachmentDraft.SaveNewPhoto(attachmentFiler, AttachmentsRealm, filename, stream);
+			await AttachmentDraft.SaveNewPhoto(CaseloadItem, attachmentFiler, AttachmentsRealm, filename, stream);
 		}
 		finally
 		{

--- a/visitz/Visitz/Views/Entity/Attachments/TakePhotoViewModel.cs
+++ b/visitz/Visitz/Views/Entity/Attachments/TakePhotoViewModel.cs
@@ -5,6 +5,7 @@ using Realms;
 using System.Text;
 using Visitz.Storage;
 using Visitz.Views.BaseClasses;
+using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Interfaces;
 using VisitzModel.Models;
 using VisitzModel.Models.Attachments;
@@ -47,7 +48,11 @@ internal partial class TakePhotoViewModel(ICameraProvider cameraProvider) : Visi
 		base.Create();
 
 		AttachmentsRealm = await VisitzRealms.GetAttachmentDraftsRealmAsync();
-		attachmentFiler = await VisitzFiles.GetAsync(CaseloadItem);
+		attachmentFiler = await VisitzFiles.GetAsync(
+			CaseloadItem.EntityType.ParseEntityType(),
+			CaseloadItem.CaseIncidentNumber,
+			CaseloadItem.KeyPlayer.FirstName,
+			CaseloadItem.KeyPlayer.LastName);
 
 		await SetupCameras();
 		SetupCameraRoll();

--- a/visitz/VisitzModel/Models/Attachments/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachments/Attachment.cs
@@ -228,4 +228,12 @@ public partial class Attachment : IRealmObject, IRecordInfo, IApiJson<Attachment
     {
         await RealmExtensions.CommitAsync(realm, () => realm.Upsert(FromApiArray(items, parentId, type)));
     }
+
+    public static IEnumerable<Attachment> GetAttachments(Realm realm, EntityType type, string recordId)
+    {
+        var attachments = realm.All<Attachment>()
+                        .Where(item => item.RelatedEntityType == type && item.RelatedEntityId == recordId)
+                        .OrderByDescending(item => item.CreatedDate);
+        return attachments;
+    }
 }

--- a/visitz/VisitzModel/Models/Attachments/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachments/Attachment.cs
@@ -232,7 +232,7 @@ public partial class Attachment : IRealmObject, IRecordInfo, IApiJson<Attachment
     public static IEnumerable<Attachment> GetAttachments(Realm realm, EntityType type, string recordId)
     {
         var attachments = realm.All<Attachment>()
-            .Where(item => item.RelatedEntityType == type && item.RelatedEntityId == recordId)
+            .Where(item => item.RelatedEntityTypeInt == (int)type && item.RelatedEntityId == recordId)
             .OrderByDescending(item => item.CreatedDate);
         return attachments;
     }

--- a/visitz/VisitzModel/Models/Attachments/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachments/Attachment.cs
@@ -232,8 +232,8 @@ public partial class Attachment : IRealmObject, IRecordInfo, IApiJson<Attachment
     public static IEnumerable<Attachment> GetAttachments(Realm realm, EntityType type, string recordId)
     {
         var attachments = realm.All<Attachment>()
-                        .Where(item => item.RelatedEntityType == type && item.RelatedEntityId == recordId)
-                        .OrderByDescending(item => item.CreatedDate);
+            .Where(item => item.RelatedEntityType == type && item.RelatedEntityId == recordId)
+            .OrderByDescending(item => item.CreatedDate);
         return attachments;
     }
 }

--- a/visitz/VisitzModel/Models/Attachments/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachments/Attachment.cs
@@ -149,7 +149,7 @@ public partial class Attachment : IRealmObject, IRecordInfo, IApiJson<Attachment
         FileDeferFlg = json.FileDeferFlg;
         FileDockReqFlg = json.FileDockReqFlg;
         FileDockStatFlg = json.FileDockStatFlg;
-        Extension = "." + json.FileExt.Trim('.');
+        Extension = "." + json.FileExt?.Trim('.');
         FileSize = json.FileSize;
         FileSrcPath = json.FileSrcPath;
         FileSrcType = json.FileSrcType;
@@ -192,7 +192,7 @@ public partial class Attachment : IRealmObject, IRecordInfo, IApiJson<Attachment
             FileDeferFlg = FileDeferFlg,
             FileDockReqFlg = FileDockReqFlg,
             FileDockStatFlg = FileDockStatFlg,
-            FileExt = Extension.Trim('.'),
+            FileExt = Extension?.Trim('.'),
             FileSize = FileSize,
             FileSrcPath = FileSrcPath,
             FileSrcType = FileSrcType,

--- a/visitz/VisitzModel/Models/Attachments/AttachmentDraft.cs
+++ b/visitz/VisitzModel/Models/Attachments/AttachmentDraft.cs
@@ -41,6 +41,7 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 	public Attachment Attachment { get; set; }
 
 	public static async Task<AttachmentDraft> SaveNewPhoto(
+		CaseloadItem caseloadItem,
 		AttachmentFiler filer,
 		Realm realm,
 		string filename,
@@ -53,19 +54,21 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 		if (stream.Length > Attachment.MaxFilesize)
 			stream = await imgProc.DownsizeByFilesize(Attachment.MaxFilesize);
 
-		return await MakeAndSaveDraft(filer, realm, filename, stream, thumbnail);
+		return await MakeAndSaveDraft(caseloadItem, filer, realm, filename, stream, thumbnail);
 	}
 
 	public static async Task<AttachmentDraft> SaveNewFile(
+		CaseloadItem caseloadItem,
 		AttachmentFiler filer,
 		Realm realm,
 		string filename,
 		Stream stream)
 	{
-		return await MakeAndSaveDraft(filer, realm, filename, stream);
+		return await MakeAndSaveDraft(caseloadItem, filer, realm, filename, stream);
 	}
 
 	static async Task<AttachmentDraft> MakeAndSaveDraft(
+		CaseloadItem caseloadItem,
 		AttachmentFiler filer,
 		Realm realm,
 		string filename,
@@ -76,7 +79,7 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 			ThrowSizeError(stream);
 
 		string fullpath = await filer.SaveFileAsync(stream, filename.GetFileExtension());
-		var draft = MakeDraft(filer, filename, fullpath, thumbnail);
+		var draft = MakeDraft(caseloadItem, filer, filename, fullpath, thumbnail);
 
 		try
 		{
@@ -99,7 +102,12 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 		throw new ArgumentException(GeneralStrings.FileTooLarge.Format(tooLargeSize), nameof(stream));
 	}
 
-	static AttachmentDraft MakeDraft(AttachmentFiler filer, string filename, string relativePath, byte[] thumbnail)
+	static AttachmentDraft MakeDraft(
+		CaseloadItem caseloadItem,
+		AttachmentFiler filer,
+		string filename,
+		string relativePath,
+		byte[] thumbnail)
 	{
 		int dotIndex = filename.LastIndexOf('.');
 
@@ -113,7 +121,7 @@ public partial class AttachmentDraft : IRealmObject, IDraftItem
 				Thumbnail = thumbnail,
 			},
 		};
-		draft.InitDraftWith(filer.CaseloadItem);
+		draft.InitDraftWith(caseloadItem);
 
 		return draft;
 	}

--- a/visitz/VisitzModel/Storage/Filesystem/AttachmentFiler.cs
+++ b/visitz/VisitzModel/Storage/Filesystem/AttachmentFiler.cs
@@ -1,24 +1,20 @@
 using System.Globalization;
 using VisitzModel.Encryption;
 using VisitzModel.Formats;
-using VisitzModel.Interfaces;
-using VisitzModel.Models;
 
 namespace VisitzModel.Storage.Filesystem;
 
-public class AttachmentFiler(CaseloadItem caseloadItem, byte[] key) : ICaseloadItemHolder
+public class AttachmentFiler(string EntityType, string CaseIncidentNumber, string FirstName, string LastName, byte[] key)
 {
 	static readonly string BasePath = "Attachments";
 
 	readonly Crypto cryptoHandler = new(key);
 
-	public CaseloadItem CaseloadItem { get; set; } = caseloadItem;
+	string CaseloadItemId => $"{EntityType}_{CaseIncidentNumber}";
 
-	string CaseloadItemId => $"{CaseloadItem.EntityType}_{CaseloadItem.CaseIncidentNumber}";
-
-	string ContextualName => CaseloadItem.KeyPlayer != null
-			? $"{CaseloadItem.KeyPlayer.LastName}_{CaseloadItem.KeyPlayer.FirstName}"
-			: CaseloadItemId;
+	string ContextualName => string.IsNullOrEmpty(FirstName) && string.IsNullOrEmpty(LastName)
+			? CaseloadItemId
+			: $"{LastName}_{FirstName}";
 
 	static string AppDataPath =>
 #if WINDOWS

--- a/visitz/VisitzModel/Storage/Filesystem/AttachmentFiler.cs
+++ b/visitz/VisitzModel/Storage/Filesystem/AttachmentFiler.cs
@@ -1,20 +1,21 @@
 using System.Globalization;
 using VisitzModel.Encryption;
 using VisitzModel.Formats;
+using VisitzModel.Models.EntityTypes;
 
 namespace VisitzModel.Storage.Filesystem;
 
-public class AttachmentFiler(string EntityType, string CaseIncidentNumber, string FirstName, string LastName, byte[] key)
+public class AttachmentFiler(EntityType entityType, string fileNumber, string firstName, string lastName, byte[] key)
 {
 	static readonly string BasePath = "Attachments";
 
 	readonly Crypto cryptoHandler = new(key);
 
-	string CaseloadItemId => $"{EntityType}_{CaseIncidentNumber}";
+	string CaseloadItemId => $"{entityType}_{fileNumber}";
 
-	string ContextualName => string.IsNullOrEmpty(FirstName) || string.IsNullOrEmpty(LastName)
+	string ContextualName => string.IsNullOrEmpty(firstName) || string.IsNullOrEmpty(lastName)
 			? CaseloadItemId
-			: $"{LastName}_{FirstName}";
+			: $"{lastName}_{firstName}";
 
 	static string AppDataPath =>
 #if WINDOWS

--- a/visitz/VisitzModel/Storage/Filesystem/AttachmentFiler.cs
+++ b/visitz/VisitzModel/Storage/Filesystem/AttachmentFiler.cs
@@ -12,7 +12,7 @@ public class AttachmentFiler(string EntityType, string CaseIncidentNumber, strin
 
 	string CaseloadItemId => $"{EntityType}_{CaseIncidentNumber}";
 
-	string ContextualName => string.IsNullOrEmpty(FirstName) && string.IsNullOrEmpty(LastName)
+	string ContextualName => string.IsNullOrEmpty(FirstName) || string.IsNullOrEmpty(LastName)
 			? CaseloadItemId
 			: $"{LastName}_{FirstName}";
 

--- a/visitz/VisitzModel/Storage/Filesystem/AttachmentFiler.cs
+++ b/visitz/VisitzModel/Storage/Filesystem/AttachmentFiler.cs
@@ -1,6 +1,9 @@
 using System.Globalization;
+using Realms;
+using VisitzApi.Models.Attachments;
 using VisitzModel.Encryption;
 using VisitzModel.Formats;
+using VisitzModel.Models.Attachments;
 using VisitzModel.Models.EntityTypes;
 
 namespace VisitzModel.Storage.Filesystem;
@@ -58,6 +61,20 @@ public class AttachmentFiler(EntityType entityType, string fileNumber, string fi
 	public async Task<string> SaveFileAsync(Stream stream, string extension)
 	{
 		return await WriteEncryptedFile(stream, extension);
+	}
+
+	public async Task<string> SaveFileAsync(string base64, string extension)
+	{
+		var memoryStream = new MemoryStream(Convert.FromBase64String(base64));
+		return await SaveFileAsync(memoryStream, extension);
+	}
+
+	public async Task SaveAttachmentDetailsAsync(Realm realm, AttachmentJson item, EntityType entityType, string entityId)
+	{
+		Attachment attachment = new(item, entityId, entityType);
+		string relativePath = await SaveFileAsync(item.AttachmentId, item.FileExt);
+		attachment.RelativePath = relativePath;
+		await realm.WriteAsync(() => realm.Add(attachment, update: true));
 	}
 
 	/// <summary>

--- a/visitz/VisitzModel/Storage/IcmData.cs
+++ b/visitz/VisitzModel/Storage/IcmData.cs
@@ -1,6 +1,7 @@
 using Realms;
 using Realms.Schema;
 using VisitzModel.Models;
+using VisitzModel.Models.Attachment
 using VisitzModel.Models.Caseload;
 using VisitzModel.Models.InPersonVisits;
 using VisitzModel.Models.Notes;
@@ -26,6 +27,8 @@ public class IcmData(byte[] encryptionKey) : VisitzRealmBase(Name, CurrentVersio
             typeof(IncidentRecord),
             typeof(IcmContact),
             typeof(SupportNetworkItem),
+            typeof(Attachment),
+            typeof(AttachmentDraft),
         };
     }
 


### PR DESCRIPTION
[STRY0037060: API SDK: Attachments storage support](https://bcsocialsector.service-now.com/now/nav/ui/classic/params/target/rm_story.do%3Fsys_id%3Df8f82c9e33c06ed084a805570e5c7bd8%26sysparm_view%3D%26sysparm_time%3D1741704256254)