### PR TITLE
Upgrade image sharp

### DIFF
--- a/visitz/VisitzModel/Platforms/Windows/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Platforms/Windows/Imaging/ImageProcessor.cs
@@ -39,6 +39,7 @@ public partial class ImageProcessor
 
 	static async Task<Image> ConvertToImageAsync(Stream imageBytes, CancellationToken? token = null)
 	{
+		imageBytes.Seek(0, SeekOrigin.Begin);
 		return await Image.LoadAsync(imageBytes, token ?? CancellationToken.None);
 	}
 

--- a/visitz/VisitzModel/Platforms/Windows/Imaging/ImageProcessor.cs
+++ b/visitz/VisitzModel/Platforms/Windows/Imaging/ImageProcessor.cs
@@ -13,7 +13,7 @@ public partial class ImageProcessor
 			? Task.FromResult(ImageBytes)
 			: Task.Run(async () =>
 			{
-				var image = await ConvertToImageAsync(ImageBytes);
+				using var image = await ConvertToImageAsync(ImageBytes);
 				var newMax = ResizeImageValues.MaxNewDimensionByFileSize(image.Width, image.Height, bytesLength);
 
 				ResizeImage(image, (int)newMax);
@@ -25,7 +25,7 @@ public partial class ImageProcessor
 	{
 		downsizeImageTask = Task.Run(async () =>
 		{
-			var image = await ConvertToImageAsync(ImageBytes);
+			using var image = await ConvertToImageAsync(ImageBytes);
 
 			if (Math.Max(image.Width, image.Height) > maxWidthOrHeight)
 			{

--- a/visitz/VisitzModel/VisitzModel.csproj
+++ b/visitz/VisitzModel/VisitzModel.csproj
@@ -31,7 +31,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="SharpSource" Version="$(SharpSourceVersion)" PrivateAssets="All" />
-		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.5" />
+		<PackageReference Include="SixLabors.ImageSharp" Version="3.1.7" />
 	</ItemGroup>
 
 	<ItemGroup Condition="$(TargetFramework.Contains('-windows'))">


### PR DESCRIPTION
[Fix CVE-2025-27598: Out-of-bounds Write in SixLabors ImageSharp](https://bcsocialsector.service-now.com/nav_to.do?uri=rm_story.do?sys_id=b6e4943efb54ee144e3aff907befdcfb%26sysparm_view=scrum)