### PR TITLE
Fix/attachments cascade delete

### DIFF
--- a/visitz/Visitz/Services/Caseload/GetCaseloadService.cs
+++ b/visitz/Visitz/Services/Caseload/GetCaseloadService.cs
@@ -72,7 +72,7 @@ namespace Visitz.Services.Caseload
                 await IncidentRecord.SynchronizeAsync(realm, caseloadFromApi.Incidents, UserIgnoredPrefs);
 
             if (CanSynchronize(caseloadFromApi.Memos, invalidOps))
-                await MemoRecord.SynchronizeAsync(realm, caseloadFromApi.Memos);
+                await MemoRecord.SynchronizeAsync(realm, caseloadFromApi.Memos, UserIgnoredPrefs);
 
             if (CanSynchronize(caseloadFromApi.ServiceRequests, invalidOps))
                 await ServiceRequestRecord.SynchronizeAsync(realm, caseloadFromApi.ServiceRequests);

--- a/visitz/Visitz/Services/Caseload/GetCaseloadService.cs
+++ b/visitz/Visitz/Services/Caseload/GetCaseloadService.cs
@@ -69,7 +69,7 @@ namespace Visitz.Services.Caseload
                 await CaseRecord.SynchronizeCasesAsync(realm, caseloadFromApi.Cases, UserIgnoredPrefs);
 
             if (CanSynchronize(caseloadFromApi.Incidents, invalidOps))
-                await IncidentRecord.SynchronizeAsync(realm, caseloadFromApi.Incidents);
+                await IncidentRecord.SynchronizeAsync(realm, caseloadFromApi.Incidents, UserIgnoredPrefs);
 
             if (CanSynchronize(caseloadFromApi.Memos, invalidOps))
                 await MemoRecord.SynchronizeAsync(realm, caseloadFromApi.Memos);

--- a/visitz/Visitz/Services/Caseload/GetCaseloadService.cs
+++ b/visitz/Visitz/Services/Caseload/GetCaseloadService.cs
@@ -75,7 +75,7 @@ namespace Visitz.Services.Caseload
                 await MemoRecord.SynchronizeAsync(realm, caseloadFromApi.Memos, UserIgnoredPrefs);
 
             if (CanSynchronize(caseloadFromApi.ServiceRequests, invalidOps))
-                await ServiceRequestRecord.SynchronizeAsync(realm, caseloadFromApi.ServiceRequests);
+                await ServiceRequestRecord.SynchronizeAsync(realm, caseloadFromApi.ServiceRequests, UserIgnoredPrefs);
 
             if (invalidOps.Count > 0)
                 throw new AggregateException(invalidOps);

--- a/visitz/Visitz/Services/Caseload/GetCaseloadService.cs
+++ b/visitz/Visitz/Services/Caseload/GetCaseloadService.cs
@@ -13,8 +13,12 @@ using VisitzModel.Storage;
 
 namespace Visitz.Services.Caseload
 {
-    public class GetCaseloadService(Vpi vpi, LastUpdatedPrefs prefs) : VisitzApiService(vpi, prefs)
+    public class GetCaseloadService(
+        Vpi vpi,
+        LastUpdatedPrefs prefs,
+        UserIgnoredContentPrefs userIgnoredContentPrefs) : VisitzApiService(vpi, prefs)
     {
+        UserIgnoredContentPrefs UserIgnoredPrefs { get; } = userIgnoredContentPrefs;
         public static string MakeId()
         {
             return nameof(GetCaseloadService);
@@ -62,7 +66,7 @@ namespace Visitz.Services.Caseload
             List<InvalidOperationException> invalidOps = [];
 
             if (CanSynchronize(caseloadFromApi.Cases, invalidOps))
-                await CaseRecord.SynchronizeCasesAsync(realm, caseloadFromApi.Cases);
+                await CaseRecord.SynchronizeCasesAsync(realm, caseloadFromApi.Cases, UserIgnoredPrefs);
 
             if (CanSynchronize(caseloadFromApi.Incidents, invalidOps))
                 await IncidentRecord.SynchronizeAsync(realm, caseloadFromApi.Incidents);
@@ -107,7 +111,7 @@ namespace Visitz.Services.Caseload
         }
 
         /// <summary>
-        /// As of v1.0, it is currently a business decision to only allow users to interact with Cases and Incidents 
+        /// As of v1.0, it is currently a business decision to only allow users to interact with Cases and Incidents
         /// from their caseload.
         /// </summary>
         /// <param name="caseloadItems"></param>

--- a/visitz/VisitzModel/Models/Attachments/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachments/Attachment.cs
@@ -293,7 +293,7 @@ public partial class Attachment : IRealmObject, IRecordInfo, IApiJson<Attachment
 
         foreach (var item in attachmentItems)
         {
-            if(!string.IsNullOrWhiteSpace(item.RelativePath))
+            if(item.FileExistsLocally)
                 item.RemoveFileFromDevice();
             userIgnoredPrefs.RemoveUserIgnoredContent(item.Id);
             realm.Remove(item);

--- a/visitz/VisitzModel/Models/Attachments/Attachment.cs
+++ b/visitz/VisitzModel/Models/Attachments/Attachment.cs
@@ -5,6 +5,7 @@ using VisitzModel.Formats;
 using VisitzModel.Interfaces;
 using VisitzModel.Models.EntityTypes;
 using VisitzModel.Models.Interfaces;
+using VisitzModel.Storage;
 using VisitzModel.Storage.Filesystem;
 
 namespace VisitzModel.Models.Attachments;
@@ -282,5 +283,20 @@ public partial class Attachment : IRealmObject, IRecordInfo, IApiJson<Attachment
     {
         AttachmentFiler.DeleteFileFromDevice(RelativePath);
         RelativePathBinding = string.Empty;
+    }
+
+    public static void RemoveByParent(Realm realm, EntityType type, string parentId, UserIgnoredContentPrefs userIgnoredPrefs)
+    {
+        var attachmentItems = realm.All<Attachment>()
+            .Where(item => item.RelatedEntityId == parentId && item.RelatedEntityTypeInt == (int)type)
+            .ToList();
+
+        foreach (var item in attachmentItems)
+        {
+            if(!string.IsNullOrWhiteSpace(item.RelativePath))
+                item.RemoveFileFromDevice();
+            userIgnoredPrefs.RemoveUserIgnoredContent(item.Id);
+            realm.Remove(item);
+        }
     }
 }

--- a/visitz/VisitzModel/Models/Caseload/CaseRecord.cs
+++ b/visitz/VisitzModel/Models/Caseload/CaseRecord.cs
@@ -3,10 +3,12 @@ using VisitzApi.Models.Caseload;
 using VisitzModel.Extensions;
 using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Interfaces;
+using VisitzModel.Models.Attachments;
 using VisitzModel.Models.EntityTypes;
 using VisitzModel.Models.InPersonVisits;
 using VisitzModel.Models.Interfaces;
 using VisitzModel.Models.People;
+using VisitzModel.Storage;
 using VisitzModel.Utilities;
 
 namespace VisitzModel.Models.Caseload;
@@ -169,7 +171,7 @@ public partial class CaseRecord :
         return outList;
     }
 
-    public static async Task SynchronizeCasesAsync(Realm realm, SectionJson<CaseJson> section)
+    public static async Task SynchronizeCasesAsync(Realm realm, SectionJson<CaseJson> section, UserIgnoredContentPrefs userIgnoredPrefs)
     {
         var currentAssignedIds = realm.All<CaseRecord>().AsEnumerable().Select(@case => @case.Id);
         var unassignedIds = currentAssignedIds.Except(section.AssignedIds);
@@ -183,7 +185,7 @@ public partial class CaseRecord :
 
         await RealmExtensions.CommitAsync(realm, () =>
         {
-            CascadeDelete(realm, unassignedIds);
+            CascadeDelete(realm, unassignedIds, userIgnoredPrefs);
             realm.Upsert(v2Cases);
 
             // TODO: Remove this foreach loop once we've fully removed V1 CaseloadItems
@@ -192,7 +194,7 @@ public partial class CaseRecord :
         });
     }
 
-    static void CascadeDelete(Realm realm, IEnumerable<string> unassignedIds)
+    static void CascadeDelete(Realm realm, IEnumerable<string> unassignedIds, UserIgnoredContentPrefs userIgnoredPrefs)
     {
         foreach (var id in unassignedIds)
         {
@@ -202,7 +204,7 @@ public partial class CaseRecord :
             PersonVisit.RemoveByParent(realm, EntityType.Case, id);
             IcmContact.RemoveByParent(realm, EntityType.Case, id);
             SupportNetworkItem.RemoveByParent(realm, EntityType.Case, id);
-            // TODO: Remove Attachments
+            Attachment.RemoveByParent(realm, EntityType.Case, id, userIgnoredPrefs);
         }
     }
 }

--- a/visitz/VisitzModel/Models/Caseload/IncidentRecord.cs
+++ b/visitz/VisitzModel/Models/Caseload/IncidentRecord.cs
@@ -3,9 +3,11 @@ using VisitzApi.Models.Caseload;
 using VisitzModel.Extensions;
 using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Interfaces;
+using VisitzModel.Models.Attachments;
 using VisitzModel.Models.EntityTypes;
 using VisitzModel.Models.Interfaces;
 using VisitzModel.Models.People;
+using VisitzModel.Storage;
 using VisitzModel.Utilities;
 
 namespace VisitzModel.Models.Caseload;
@@ -216,7 +218,7 @@ public partial class IncidentRecord :
         return outList;
     }
 
-    public static async Task SynchronizeAsync(Realm realm, SectionJson<IncidentJson> section)
+    public static async Task SynchronizeAsync(Realm realm, SectionJson<IncidentJson> section, UserIgnoredContentPrefs userIgnoredPrefs)
     {
         var currentAssignedIds = realm.All<IncidentRecord>().AsEnumerable().Select(incident => incident.Id);
         var unassignedIds = currentAssignedIds.Except(section.AssignedIds);
@@ -227,7 +229,7 @@ public partial class IncidentRecord :
 
         await RealmExtensions.CommitAsync(realm, () =>
         {
-            CascadeDelete(realm, unassignedIds);
+            CascadeDelete(realm, unassignedIds, userIgnoredPrefs);
             realm.Upsert(v2Incidents);
 
             // TODO: Remove this foreach loop once we've fully removed V1 CaseloadItems
@@ -237,7 +239,7 @@ public partial class IncidentRecord :
         });
     }
 
-    static void CascadeDelete(Realm realm, IEnumerable<string> deleteIds)
+    static void CascadeDelete(Realm realm, IEnumerable<string> deleteIds, UserIgnoredContentPrefs userIgnoredPrefs)
     {
         foreach (var id in deleteIds)
         {
@@ -246,7 +248,7 @@ public partial class IncidentRecord :
             // TODO: Remove notes here once we remove V1 CaseloadItem
             IcmContact.RemoveByParent(realm, EntityType.Incident, id);
             SupportNetworkItem.RemoveByParent(realm, EntityType.Incident, id);
-            // TODO: Remove Attachments
+            Attachment.RemoveByParent(realm, EntityType.Incident, id, userIgnoredPrefs);
         }
     }
 }

--- a/visitz/VisitzModel/Models/Caseload/MemoRecord.cs
+++ b/visitz/VisitzModel/Models/Caseload/MemoRecord.cs
@@ -2,9 +2,11 @@ using Realms;
 using VisitzApi.Models.Caseload;
 using VisitzModel.Extensions;
 using VisitzModel.Interfaces;
+using VisitzModel.Models.Attachments;
 using VisitzModel.Models.EntityTypes;
 using VisitzModel.Models.Interfaces;
 using VisitzModel.Models.People;
+using VisitzModel.Storage;
 using VisitzModel.Utilities;
 
 namespace VisitzModel.Models.Caseload;
@@ -161,7 +163,7 @@ public partial class MemoRecord :
         return outList;
     }
 
-    public static async Task SynchronizeAsync(Realm realm, SectionJson<MemoJson> section)
+    public static async Task SynchronizeAsync(Realm realm, SectionJson<MemoJson> section, UserIgnoredContentPrefs userIgnoredPrefs)
     {
         var currentAssignedIds = realm.All<MemoRecord>().AsEnumerable().Select(memo => memo.Id);
         var unassignedIds = currentAssignedIds.Except(section.AssignedIds);
@@ -169,19 +171,19 @@ public partial class MemoRecord :
 
         await RealmExtensions.CommitAsync(realm, () =>
         {
-            CascadeDelete(realm, unassignedIds);
+            CascadeDelete(realm, unassignedIds, userIgnoredPrefs);
             realm.Upsert(memos);
         });
     }
 
-    static void CascadeDelete(Realm realm, IEnumerable<string> unassignedIds)
+    static void CascadeDelete(Realm realm, IEnumerable<string> unassignedIds, UserIgnoredContentPrefs userIgnoredPrefs)
     {
         foreach (var id in unassignedIds)
         {
             realm.Remove(realm.Find<MemoRecord>(id));
 
             IcmContact.RemoveByParent(realm, EntityType.Memo, id);
-            // TODO: Remove Attachments
+            Attachment.RemoveByParent(realm, EntityType.Memo, id, userIgnoredPrefs);
         }
     }
 

--- a/visitz/VisitzModel/Models/Caseload/ServiceRequestRecord.cs
+++ b/visitz/VisitzModel/Models/Caseload/ServiceRequestRecord.cs
@@ -3,9 +3,11 @@ using VisitzApi.Models.Caseload;
 using VisitzModel.Extensions;
 using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Interfaces;
+using VisitzModel.Models.Attachments;
 using VisitzModel.Models.EntityTypes;
 using VisitzModel.Models.Interfaces;
 using VisitzModel.Models.People;
+using VisitzModel.Storage;
 using VisitzModel.Utilities;
 
 namespace VisitzModel.Models.Caseload;
@@ -152,7 +154,7 @@ public partial class ServiceRequestRecord :
         return outList;
     }
 
-    public static async Task SynchronizeAsync(Realm realm, SectionJson<ServiceRequestJson> section)
+    public static async Task SynchronizeAsync(Realm realm, SectionJson<ServiceRequestJson> section, UserIgnoredContentPrefs userIgnoredPrefs)
     {
         var currentAssignedIds = realm.All<ServiceRequestRecord>().AsEnumerable().Select(sr => sr.Id);
         var unassignedIds = currentAssignedIds.Except(section.AssignedIds);
@@ -160,12 +162,12 @@ public partial class ServiceRequestRecord :
 
         await RealmExtensions.CommitAsync(realm, () =>
         {
-            CascadeDelete(realm, unassignedIds);
+            CascadeDelete(realm, unassignedIds, userIgnoredPrefs);
             realm.Upsert(serviceRequests);
         });
     }
 
-    static void CascadeDelete(Realm realm, IEnumerable<string> unassignedIds)
+    static void CascadeDelete(Realm realm, IEnumerable<string> unassignedIds, UserIgnoredContentPrefs userIgnoredPrefs)
     {
         foreach (var id in unassignedIds)
         {
@@ -174,7 +176,7 @@ public partial class ServiceRequestRecord :
             // TODO: Remove notes here once we remove V1 CaseloadItem
             IcmContact.RemoveByParent(realm, EntityType.ServiceRequest, id);
             SupportNetworkItem.RemoveByParent(realm, EntityType.ServiceRequest, id);
-            // TODO: Remove Attachments
+            Attachment.RemoveByParent(realm, EntityType.ServiceRequest, id, userIgnoredPrefs);
         }
     }
 

--- a/visitz/VisitzModel/Storage/UserIgnoredContentPrefs.cs
+++ b/visitz/VisitzModel/Storage/UserIgnoredContentPrefs.cs
@@ -18,5 +18,11 @@ public class UserIgnoredContentPrefs(IPreferences prefs)
         var fullKey = IgnoredContentKeyPrefix + key;
         return Preferences.ContainsKey(fullKey) ? Preferences.Get(fullKey, false) : null;
     }
+
+    public void RemoveUserIgnoredContent(string key)
+    {
+        var fullKey = IgnoredContentKeyPrefix + key;
+        Preferences.Remove(fullKey);
+    }
 }
 


### PR DESCRIPTION
[Cascade delete local attachments when parent records are unassigned](https://bcsocialsector.service-now.com/rm_story.do?sys_id=8583705efb89e6104e3aff907befdc06&sysparm_view=backlog&sysparm_domain=null&sysparm_domain_scope=null)