### PR TITLE
Title casing entity type

### DIFF
--- a/visitz/Visitz/Services/Notes/GetNotesService.cs
+++ b/visitz/Visitz/Services/Notes/GetNotesService.cs
@@ -2,6 +2,7 @@ using Visitz.Services.Base;
 using Visitz.Services.Messages;
 using Visitz.Storage;
 using VisitzApi;
+using VisitzModel.Extensions;
 using VisitzModel.Extensions.EntityTypes;
 using VisitzModel.Models.EntityTypes;
 using VisitzModel.Models.Notes;
@@ -48,7 +49,9 @@ namespace Visitz.Services.Notes
         {
             var (id, entityType) = PayloadTuple;
 
-            var notesFromApi = await Vpi.GetNotesAsync(id, entityType.GetDisplayString());
+            string casedType = entityType.GetDisplayString().ToTitleCase();
+            var notesFromApi = await Vpi.GetNotesAsync(id, casedType);
+
             var newNotes = NoteItem.FromApiEntities(id, entityType, notesFromApi);
 
             await VisitzRealms.EnqueueIcmDataActionAsync(async realm =>

--- a/visitz/Visitz/Views/Entity/EntityContainerView.xaml
+++ b/visitz/Visitz/Views/Entity/EntityContainerView.xaml
@@ -36,7 +36,7 @@
 				
 				<Label
 					FontSize="{StaticResource TitleMediumFontSize}"
-					Text="{Binding BusinessObject.FullType}"
+					Text="{Binding FullTypeCased}"
 					TextColor="{Binding EntityTypeTextColor}" />
 			</HorizontalStackLayout>
         </Grid>

--- a/visitz/Visitz/Views/Entity/EntityContainerViewModel.cs
+++ b/visitz/Visitz/Views/Entity/EntityContainerViewModel.cs
@@ -15,11 +15,12 @@ public partial class EntityContainerViewModel : VisitzViewModel, IBusinessObject
     [ObservableProperty]
     public Color entityTypeTextColor;
 
+    [ObservableProperty]
+    public string fullTypeCased;
+
     partial void OnBusinessObjectChanged(IBusinessObject oldValue, IBusinessObject newValue)
     {
-        if (newValue != null)
-            EntityTypeTextColor = newValue.EntityType.GetTextColor();
-        else
-            EntityTypeTextColor = VisitzColors.BC_TextColor;
+        EntityTypeTextColor = newValue?.EntityType.GetTextColor() ?? VisitzColors.BC_TextColor;
+        FullTypeCased = newValue?.FullType.ToTitleCase();
     }
 }

--- a/visitz/VisitzModel/Extensions/StringExtensions.cs
+++ b/visitz/VisitzModel/Extensions/StringExtensions.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+
 namespace VisitzModel.Extensions;
 
 public static class StringExtensions
@@ -59,5 +61,10 @@ public static class StringExtensions
             return "No";
 
         return null;
+    }
+
+    public static string ToTitleCase(this string text)
+    {
+        return CultureInfo.CurrentCulture.TextInfo.ToTitleCase(text ?? "");
     }
 }


### PR DESCRIPTION
[STRY0041059](https://bcsocialsector.service-now.com/rm_story.do?sys_id=c41f2ee4fb9aee144e3aff907befdce9&sysparm_view=&sysparm_time=1751556217166)

Use title case when for entity types when sending upstream and when displaying in UI header.