### PR TITLE
Change wording for "pull to refresh" based on platform

### DIFF
--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.Designer.cs
@@ -259,6 +259,15 @@ namespace Visitz.Resources.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Use download button to refresh caseload.
+        /// </summary>
+        public static string ButtonToRefreshCaseload {
+            get {
+                return ResourceManager.GetString("ButtonToRefreshCaseload", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Cancel.
         /// </summary>
         public static string Cancel {

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.fr.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.fr.resx
@@ -127,4 +127,7 @@
   <data name="Deceased" type="System.Resources.ResXNullRef, System.Windows.Forms">
     <value />
   </data>
+  <data name="ButtonToRefreshCaseload" type="System.Resources.ResXNullRef, System.Windows.Forms">
+    <value />
+  </data>
 </root>

--- a/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
+++ b/visitz/Visitz/Resources/Localization/LocalizedStrings.resx
@@ -1018,4 +1018,7 @@ Do you want to download information for this record?</value>
   <data name="Incidents" xml:space="preserve">
     <value>Incidents</value>
   </data>
+  <data name="ButtonToRefreshCaseload" xml:space="preserve">
+    <value>Use download button to refresh caseload</value>
+  </data>
 </root>

--- a/visitz/Visitz/Views/Caseload/CaseloadView.xaml
+++ b/visitz/Visitz/Views/Caseload/CaseloadView.xaml
@@ -180,7 +180,7 @@
 							Padding="20"
 							Spacing="10">
                             <Label 
-                                HorizontalOptions="Center"
+                                HorizontalOptions="Fill"
 								HorizontalTextAlignment="Center"
                                 FontSize="16"
                                 Text="{Binding CollectionViewPrompt}" />

--- a/visitz/Visitz/Views/Caseload/CaseloadViewModel.cs
+++ b/visitz/Visitz/Views/Caseload/CaseloadViewModel.cs
@@ -27,6 +27,12 @@ namespace Visitz.Views.Caseload
     /// </summary>
     public partial class CaseloadViewModel : VisitzViewModel, IRecipient<ServiceStateMessage>
     {
+#if WINDOWS
+        private static readonly string PromptText = LocalizedStrings.ButtonToRefreshCaseload;
+#else
+        private static readonly string PromptText = LocalizedStrings.PullToRefreshCaseload;
+#endif
+
         private static readonly string SortOptionIndexPref = "SortOptionIndexPref";
 
         private static readonly SegmentedOptions SortKeyPlayer = new(
@@ -119,7 +125,7 @@ namespace Visitz.Views.Caseload
             ActivatedSortOption = SortOptions.ElementAt(sortPrefIndex);
 
             ShowEmptyCaseloadMessage = false;
-            CollectionViewPrompt = LocalizedStrings.PullToRefreshCaseload;
+            CollectionViewPrompt = PromptText;
 
             DeviceDisplay.Current.MainDisplayInfoChanged += Current_MainDisplayInfoChanged;
             ShowAvatarView = DeviceDisplay.Current.MainDisplayInfo.Orientation == DisplayOrientation.Portrait;
@@ -318,7 +324,7 @@ namespace Visitz.Views.Caseload
         {
             CollectionViewPrompt = !string.IsNullOrWhiteSpace(SearchQuery)
                 ? LocalizedStrings.NoResultsForSearch.Format(SearchQuery)
-                : LocalizedStrings.PullToRefreshCaseload;
+                : PromptText;
         }
 
         [RelayCommand]


### PR DESCRIPTION
[STRY0042582](https://bcsocialsector.service-now.com/rm_story.do?sys_id=e51ccfce2bab6a10f81ff644ce91bffa&sysparm_view=&sysparm_time=1763406596519)