### PR TITLE
Don't run CSharpier on release builds

### DIFF
--- a/visitz/Visitz/Visitz.csproj
+++ b/visitz/Visitz/Visitz.csproj
@@ -49,6 +49,10 @@
 		<DefaultLanguage>en</DefaultLanguage>
 	</PropertyGroup>
 
+	<PropertyGroup Condition="'$(Configuration)' == 'Release'">
+		<CSharpier_Bypass>true</CSharpier_Bypass>
+	</PropertyGroup>
+
 	<PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|net10.0-ios|AnyCPU'">
 		<CreatePackage>false</CreatePackage>
 	</PropertyGroup>


### PR DESCRIPTION
CSharpier causing issues when running release builds because of our XmlPoke tasks.