### PR TITLE
Upgrade MAUI and community toolkit

### DIFF
--- a/visitz/Visitz/Visitz.csproj
+++ b/visitz/Visitz/Visitz.csproj
@@ -99,7 +99,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.0" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="14.0.1" />
 		<PackageReference Include="CommunityToolkit.Maui.Camera" Version="6.0.0" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="$(CommunityToolkitMvvmVersion)" />
 		<PackageReference Include="CSharpier.MsBuild" Version="$(CSharpierVersion)">

--- a/visitz/Visitz/Visitz.props
+++ b/visitz/Visitz/Visitz.props
@@ -3,7 +3,7 @@
 		<CSharpierVersion>1.2.6</CSharpierVersion>
 		<CommunityToolkitMvvmVersion>8.4.0</CommunityToolkitMvvmVersion>
 		<CoverletCollectorVersion>6.0.4</CoverletCollectorVersion>
-		<MauiPackageVersion>10.0.31</MauiPackageVersion>
+		<MauiPackageVersion>10.0.41</MauiPackageVersion>
 		<NETTestSdkVersion>18.0.1</NETTestSdkVersion>
 		<RealmVersion>20.1.0</RealmVersion>
 		<SecurityCodeScanVersion>5.6.7</SecurityCodeScanVersion>


### PR DESCRIPTION
[STRY0044871](https://bcsocialsector.service-now.com/rm_story.do?sys_id=f2ed0b9e333fbe5084a805570e5c7bb0&sysparm_view=&sysparm_time=1774461119223)

Upgrading to MAUI 10.0.41 and CommunityToolkit.Maui 14.0.1 to fix a transitive dependency issue from the toolkit.