### PR TITLE
Replace obsolete attribute with FIXME statement

### DIFF
--- a/visitz/VisitzModel/Storage/UserIgnoredContentPrefs.cs
+++ b/visitz/VisitzModel/Storage/UserIgnoredContentPrefs.cs
@@ -1,8 +1,13 @@
-using VisitzModel.Models.Caseload;
-
 namespace VisitzModel.Storage;
 
-[Obsolete($"Use {nameof(BoLocalState)} instead")]
+/// <summary>
+/// <para>Stores which attachments the user wants the app to ignore when
+/// refreshing data.</para>
+///
+/// <para>FIXME: When feasible, this class should be replaced by using
+/// BoLocalState instead—or when a new DB system is implemented.</para>
+/// </summary>
+/// <param name="prefs"></param>
 public class UserIgnoredContentPrefs(IPreferences prefs)
 {
     private const string IgnoredContentKeyPrefix = "UserIgnoredContent";


### PR DESCRIPTION
I'd like to replace the `UserIgnoredContentPrefs` class with `BoLocalState` instead, so I originally marked it as obsolete so as not to forget about it. But the log spam it produces every build is large, and keeping track could be better served with a GH issue + FIXME label.