### PR TITLE
Restore ToList call

### DIFF
--- a/visitz/Visitz/Services/Caseload/GetAllDataForOfflineService.cs
+++ b/visitz/Visitz/Services/Caseload/GetAllDataForOfflineService.cs
@@ -109,7 +109,8 @@ namespace Visitz.Services.Caseload
                 .All<T>()
                 .AsEnumerable()
                 .Where(bo => bo.LocalState.ShouldDownloadDuringRefresh)
-                .Select(bo => new RecordServiceInfo(bo));
+                .Select(bo => new RecordServiceInfo(bo))
+                .ToList();
         }
 
         private async Task GetPersonalCaseload()


### PR DESCRIPTION
Adding back a ToList call I erroneously removed in a previous commit. This is needed to materialize the collection before the realm instance gets garbage collected.