### PR TITLE
Fixes/enhancements for 2.9.1

### DIFF
--- a/.github/workflows/auto-builds.yaml
+++ b/.github/workflows/auto-builds.yaml
@@ -7,11 +7,13 @@ on:
       - opened
       - synchronize
     paths:
-      .github/**/*
-      visitz/**/*
+      - '.github/**/*'
+      - 'visitz/**/*'
 
 permissions:
   contents: read
+  actions: read
+  checks: write
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -35,12 +37,18 @@ jobs:
         run: |
           echo "build_number=$(($BUILD_NUM_OFFSET + $RUN_NUMBER))" >> $GITHUB_OUTPUT
 
+  run-unit-tests:
+    uses: ./.github/workflows/unit-test-maui.yaml
+
   build-ios-per-environment:
-    needs: calculate-build-number
+    needs: 
+      - calculate-build-number
+      - run-unit-tests
     strategy:
       matrix:
-        target: [demo, project-team]
+        target: [demo, project-team, prod]
     uses: ./.github/workflows/make-ios-build.yaml
     with:
-      target: ${{ matrix.target }}
+      environment: ${{ matrix.target }}
       build_number: ${{ needs.calculate-build-number.outputs.build_number }}
+    secrets: inherit

--- a/.github/workflows/make-ios-build.yaml
+++ b/.github/workflows/make-ios-build.yaml
@@ -27,7 +27,7 @@ jobs:
 
   build-ios-package:
     name: Building, archiving and uploading IPA to GitHub
-    runs-on: macOS-15
+    runs-on: macOS-26
     environment: ${{ inputs.environment }}
     timeout-minutes: 200
     steps:

--- a/.github/workflows/make-ios-build.yaml
+++ b/.github/workflows/make-ios-build.yaml
@@ -21,7 +21,7 @@ env:
   PROJPATH: "visitz/Visitz"
   DOTNET_SDK_VERSION: "9.0.313"
   GLOBAL_JSON_PATH: "global.json"
-  XCODE_VERSION: "26.4.1"
+  XCODE_VERSION: "26.3"
 
 jobs:
 

--- a/.github/workflows/make-ios-build.yaml
+++ b/.github/workflows/make-ios-build.yaml
@@ -1,22 +1,27 @@
 name: Build iOS release package
 
-run-name: Build iOS release package (${{ github.event.inputs.environment }})
+run-name: Build iOS release package (${{ inputs.environment }} ${{ inputs.build_number}})
 
 on:
-  workflow_dispatch:
+  workflow_call:
     inputs:
       environment:
+        type: string
         description: 'Environment to build package for'
-        type: environment
+        required: true
+      build_number:
+        type: string
         required: true
 
+permissions:
+  contents: read
+
 env:
-  BUILD_NUM_OFFSET: 246 # Final run number from previous repo before migration
-  RUN_NUMBER: ${{ github.run_number }}
+  BUILD_NUM: ${{ inputs.build_number }}
   PROJPATH: "visitz/Visitz"
   DOTNET_SDK_VERSION: "9.0.305"
   GLOBAL_JSON_PATH: "global.json"
-  XCODE_VERSION: "16.4"
+  XCODE_VERSION: "26.2"
 
 jobs:
 
@@ -27,25 +32,27 @@ jobs:
     timeout-minutes: 200
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Get build version
+        run: |
+          OUTPUT_VERSION=$(xmllint --xpath 'string(/Project/PropertyGroup/VisitzVersion)' ${{ env.PROJPATH }}/Visitz.props)
+          echo "OUTPUT_VERSION=$OUTPUT_VERSION" >> "$GITHUB_ENV"
 
       - name: Set build name
         run: |
-          BUILD_NUM=$(($BUILD_NUM_OFFSET + $RUN_NUMBER))
-          echo "BUILD_NUM=$BUILD_NUM" >> "$GITHUB_ENV"
-          
           # TODO: read "MCFD Mobility" app name from MSBuild instead
 
-          OUTPUT_NAME="MCFD Mobility-iOS-${{ github.event.inputs.environment }}-build_$BUILD_NUM"
+          OUTPUT_NAME="MCFD Mobility-iOS-${{ vars.ENV_LABEL }}-$OUTPUT_VERSION.$BUILD_NUM"
           echo "OUTPUT_NAME=$OUTPUT_NAME" >> "$GITHUB_ENV"
 
       - name: Setup Xcode version
-        uses: maxim-lobanov/setup-xcode@v1.6.0
+        uses: maxim-lobanov/setup-xcode@ed7a3b1fda3918c0306d1b724322adc0b8cc0a90 # v1.7.0
         with:
           xcode-version: ${{ env.XCODE_VERSION }}
 
       - name: Import code-signing certificates
-        uses: Apple-Actions/import-codesign-certs@v3
+        uses: Apple-Actions/import-codesign-certs@b610f78488812c1e56b20e6df63ec42d833f2d14 # v6.1.0
         with: 
           p12-file-base64: ${{ secrets.APPLE_ENTERPRISE_BUILD_CERTIFICATE_BASE_64 }}
           p12-password: ${{ secrets.APPLE_ENTERPRISE_BUILD_CERTIFICATE_PASSWORD }}
@@ -89,41 +96,37 @@ jobs:
           cp ${{ env.GLOBAL_JSON_PATH }}.template ${{ env.GLOBAL_JSON_PATH }}
 
       - name: Force .NET SDK version ${{ env.DOTNET_SDK_VERSION }}
-        uses: jossef/action-set-json-field@v2.2
+        uses: jossef/action-set-json-field@890d7642122dbb2833dddd2003659bb71a2b21fe # v2.2
         with:
           file: ${{ env.GLOBAL_JSON_PATH }}
           field: sdk.version
           value: ${{ env.DOTNET_SDK_VERSION }}
 
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4.3.0
+      - name: Setup JFrog CLI
+        uses: jfrog/setup-jfrog-cli@1641575d87647fb969c0545f0b6a76873e328b7c # v5.0.0
         with:
-          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
+          disable-job-summary: true
+        env:
+          JF_PROJECT: ${{ secrets.ARTIFACTORY_PROJECT }}
+          JF_URL: ${{ vars.ARTIFACTORY_URL }}
+          JF_USER: ${{ secrets.ARTIFACTORY_SERVICE_ACCOUNT_USER }}
+          JF_PASSWORD: ${{ secrets.ARTIFACTORY_SERVICE_ACCOUNT_PWD }}
 
-      - name: Cache .NET dependencies
-        uses: actions/cache@v4.2.4
-        if: always()
+      - name: Setup .NET SDK and workloads
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # 5.2.0
         with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
-
-      - name: Cache .NET workloads
-        uses: actions/cache@v4.2.4
-        if: always()
-        with:
-          path: ~/.dotnet
-          key: ${{ runner.os }}-dotnet-workloads-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            ${{ runner.os }}-dotnet-workloads-
+          cache-dependency-path: ${{ env.PROJPATH }}/packages.lock.json
+          cache: true
+          global-json-file: ${{ env.GLOBAL_JSON_PATH }}
 
       - name: Install .NET MAUI ${{ env.MAUI_WORKLOAD_VERSION }} workloads
         run: |
+          dotnet --version
           dotnet workload install maui maui-ios --version ${{ env.DOTNET_SDK_VERSION }}
 
       - name: .NET release build for iOS (${{ inputs.environment }})
         run: |
+          dotnet --version
           dotnet publish $PROJPATH \
             --framework net9.0-ios \
             --configuration Release \
@@ -147,8 +150,14 @@ jobs:
           cd ${{ env.PROJPATH }}/bin/Release/net9.0-ios/ios-arm64/publish
           mv "MCFD Mobility.ipa" "$OUTPUT_NAME.ipa"
 
-      - name: Upload IPA archive (${{ inputs.environment }})
-        uses: actions/upload-artifact@v4.6.1
-        with:
-          name: ${{ env.OUTPUT_NAME }}
-          path: ${{ env.PROJPATH }}/bin/Release/net9.0-ios/ios-arm64/publish/*.ipa
+      - name: Push build to Artifactory
+        env:
+          # TODO: make URL for job run (https://stackoverflow.com/a/70566764)
+          ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          jf rt upload \
+            "${{ env.PROJPATH }}/bin/Release/net10.0-ios/ios-arm64/publish/$OUTPUT_NAME.ipa" \
+            "${{ secrets.ARTIFACTORY_REPO_NAME }}/${{ vars.ENV_LABEL }}-iOS/$OUTPUT_NAME.ipa" \
+            --build-name="$OUTPUT_NAME" \
+            --build-number="$OUTPUT_VERSION.$BUILD_NUM" \
+            --target-props="version=$OUTPUT_VERSION;commit=${{ github.sha }};action_url=$ACTION_URL"

--- a/.github/workflows/make-ios-build.yaml
+++ b/.github/workflows/make-ios-build.yaml
@@ -64,7 +64,9 @@ jobs:
         run: |
           echo -n "$APPLE_ENTERPRISE_BUILD_CERTIFICATE_BASE_64" | base64 --decode -o $TEMP_CERT_PATH
 
-          SUBJECT=$(openssl pkcs12 -in "$TEMP_CERT_PATH" \
+          SUBJECT=$(openssl pkcs12 \
+            -legacy \
+            -in "$TEMP_CERT_PATH" \
             -password pass:"${{ secrets.APPLE_ENTERPRISE_BUILD_CERTIFICATE_PASSWORD }}" \
             -nodes -nokeys \
             | openssl x509 -noout -subject)

--- a/.github/workflows/make-ios-build.yaml
+++ b/.github/workflows/make-ios-build.yaml
@@ -156,7 +156,7 @@ jobs:
           ACTION_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           jf rt upload \
-            "${{ env.PROJPATH }}/bin/Release/net10.0-ios/ios-arm64/publish/$OUTPUT_NAME.ipa" \
+            "${{ env.PROJPATH }}/bin/Release/net9.0-ios/ios-arm64/publish/$OUTPUT_NAME.ipa" \
             "${{ secrets.ARTIFACTORY_REPO_NAME }}/${{ vars.ENV_LABEL }}-iOS/$OUTPUT_NAME.ipa" \
             --build-name="$OUTPUT_NAME" \
             --build-number="$OUTPUT_VERSION.$BUILD_NUM" \

--- a/.github/workflows/make-ios-build.yaml
+++ b/.github/workflows/make-ios-build.yaml
@@ -19,9 +19,9 @@ permissions:
 env:
   BUILD_NUM: ${{ inputs.build_number }}
   PROJPATH: "visitz/Visitz"
-  DOTNET_SDK_VERSION: "9.0.305"
+  DOTNET_SDK_VERSION: "9.0.313"
   GLOBAL_JSON_PATH: "global.json"
-  XCODE_VERSION: "26.2"
+  XCODE_VERSION: "26.4"
 
 jobs:
 

--- a/.github/workflows/make-ios-build.yaml
+++ b/.github/workflows/make-ios-build.yaml
@@ -21,7 +21,7 @@ env:
   PROJPATH: "visitz/Visitz"
   DOTNET_SDK_VERSION: "9.0.313"
   GLOBAL_JSON_PATH: "global.json"
-  XCODE_VERSION: "26.4"
+  XCODE_VERSION: "26.4.1"
 
 jobs:
 

--- a/.github/workflows/make-ios-build.yaml
+++ b/.github/workflows/make-ios-build.yaml
@@ -115,8 +115,6 @@ jobs:
       - name: Setup .NET SDK and workloads
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # 5.2.0
         with:
-          cache-dependency-path: ${{ env.PROJPATH }}/packages.lock.json
-          cache: true
           global-json-file: ${{ env.GLOBAL_JSON_PATH }}
 
       - name: Install .NET MAUI ${{ env.MAUI_WORKLOAD_VERSION }} workloads

--- a/.github/workflows/unit-test-maui.yaml
+++ b/.github/workflows/unit-test-maui.yaml
@@ -16,7 +16,7 @@ permissions:
 
 env:
   BASE_PROJPATH: "./visitz"
-  DOTNET_SDK_VERSION: "9.0.305"
+  DOTNET_SDK_VERSION: "9.0.313"
   GLOBAL_JSON_PATH: "global.json"
 
 jobs:

--- a/.github/workflows/unit-test-maui.yaml
+++ b/.github/workflows/unit-test-maui.yaml
@@ -3,6 +3,7 @@ name: Run .NET MAUI tests
 run-name: Run .NET MAUI tests (${{ github.ref_name }})
 
 on:
+  workflow_call:
   workflow_dispatch:
   push:
     paths:
@@ -26,52 +27,31 @@ jobs:
     env:
       TEST_RESULTS: "testResults"
     steps:
-      - uses: actions/checkout@v4.1.7
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Inflate ${{ env.GLOBAL_JSON_PATH }}
         run: |
           Copy-Item .\${{ env.GLOBAL_JSON_PATH }}.template .\${{ env.GLOBAL_JSON_PATH }}
 
       - name: Force .NET SDK version ${{ env.DOTNET_SDK_VERSION }}
-        uses: jossef/action-set-json-field@v2.2
+        uses: jossef/action-set-json-field@890d7642122dbb2833dddd2003659bb71a2b21fe # v2.2
         with:
           file: ${{ env.GLOBAL_JSON_PATH }}
           field: sdk.version
           value: ${{ env.DOTNET_SDK_VERSION }}
 
-      - name: Setup .NET SDK
-        uses: actions/setup-dotnet@v4.0.1
+      - name: Setup .NET SDK and workloads
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # 5.2.0
         with:
-          dotnet-version: ${{ env.DOTNET_SDK_VERSION }}
-
-      - name: Prepare NuGet
-        run: |
-          dotnet --version
-          dotnet nuget locals all --clear
-
-      - name: Cache .NET dependencies
-        uses: actions/cache@v5.0.2
-        if: always()
-        with:
-          path: ~/.nuget/packages
-          key: ${{ runner.os }}-nuget-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            ${{ runner.os }}-nuget-
-
-      - name: Cache .NET workloads
-        uses: actions/cache@v5.0.2
-        if: always()
-        with:
-          path: ~/.dotnet
-          key: ${{ runner.os }}-dotnet-workloads-${{ hashFiles('**/*.csproj') }}
-          restore-keys: |
-            ${{ runner.os }}-dotnet-workloads-
+          cache-dependency-path: ${{ env.BASE_PROJPATH }}\Visitz\packages.lock.json
+          cache: true
+          global-json-file: ${{ env.GLOBAL_JSON_PATH }}
 
       - name: Install .NET MAUI workload
         working-directory: ${{ env.BASE_PROJPATH }}
         run: |
           dotnet --version
-          dotnet workload install maui ios maccatalyst maui-ios maui-windows --version ${{ env.DOTNET_SDK_VERSION }}
+          dotnet workload install maui ios maccatalyst maui-ios maui-windows maui-maccatalyst --version ${{ env.DOTNET_SDK_VERSION }}
 
       - name: Build solution
         working-directory: ${{ env.BASE_PROJPATH }}
@@ -92,7 +72,7 @@ jobs:
             --no-build
 
       - name: Report tests
-        uses: dorny/test-reporter@v1.8.0
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3.0.0
         if: success() || failure()
         with:
           name: Visitz MAUI Tests

--- a/.github/workflows/unit-test-maui.yaml
+++ b/.github/workflows/unit-test-maui.yaml
@@ -43,8 +43,6 @@ jobs:
       - name: Setup .NET SDK and workloads
         uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # 5.2.0
         with:
-          cache-dependency-path: ${{ env.BASE_PROJPATH }}\Visitz\packages.lock.json
-          cache: true
           global-json-file: ${{ env.GLOBAL_JSON_PATH }}
 
       - name: Install .NET MAUI workload

--- a/visitz/Oidc/OidcSession.cs
+++ b/visitz/Oidc/OidcSession.cs
@@ -14,7 +14,8 @@ namespace Oidc
     public class OidcSession
     {
         private static readonly string IdirActiveKey = "idir_active_employee";
-        private static readonly SemaphoreSlim Semaphore = new(1);
+        private static readonly SemaphoreSlim s_validSession = new(1);
+        private static readonly SemaphoreSlim s_canSetAuthorization = new(1);
 
         public static readonly double StaleThresholdMinutes = 7 * TimeSpan.MinutesPerDay;
 
@@ -48,7 +49,7 @@ namespace Oidc
             string messageIfUnavailable,
             CancellationToken cancellationToken = default)
         {
-            await Semaphore.WaitAsync(cancellationToken);
+            await s_validSession.WaitAsync(cancellationToken);
 
             try
             {
@@ -58,7 +59,7 @@ namespace Oidc
             {
                 try
                 {
-                    Semaphore.Release();
+                    s_validSession.Release();
                 }
                 catch { }
             }
@@ -201,10 +202,26 @@ namespace Oidc
 
         public static async Task SetAuthorization(bool? authorized)
         {
-            if (authorized is bool auth)
-                await SecureStorage.Default.SetAsync(IdirActiveKey, auth.ToString());
-            else
-                SecureStorage.Default.Remove(IdirActiveKey);
+            await s_canSetAuthorization.WaitAsync();
+
+            try
+            {
+                if (authorized is bool auth)
+                    await SecureStorage.Default.SetAsync(IdirActiveKey, auth.ToString());
+                else
+                    SecureStorage.Default.Remove(IdirActiveKey);
+            }
+            finally
+            {
+                try
+                {
+                    s_canSetAuthorization.Release();
+                }
+                catch
+                {
+                    
+                }
+            }
         }
     }
 }

--- a/visitz/Oidc/OidcSession.cs
+++ b/visitz/Oidc/OidcSession.cs
@@ -13,7 +13,7 @@ namespace Oidc
 {
     public class OidcSession
     {
-        private static readonly string IdirActiveKey = "idir_active_employee";
+        private static readonly string s_idirActiveKey = "idir_active_employee";
         private static readonly SemaphoreSlim s_validSession = new(1);
         private static readonly SemaphoreSlim s_canSetAuthorization = new(1);
 
@@ -196,7 +196,7 @@ namespace Oidc
 
         public static async Task<bool?> IsAuthorizedAsync()
         {
-            var status = await SecureStorage.Default.GetAsync(IdirActiveKey);
+            var status = await SecureStorage.Default.GetAsync(s_idirActiveKey);
             return status != null ? bool.Parse(status) : null;
         }
 
@@ -207,9 +207,9 @@ namespace Oidc
             try
             {
                 if (authorized is bool auth)
-                    await SecureStorage.Default.SetAsync(IdirActiveKey, auth.ToString());
+                    await SecureStorage.Default.SetAsync(s_idirActiveKey, auth.ToString());
                 else
-                    SecureStorage.Default.Remove(IdirActiveKey);
+                    SecureStorage.Default.Remove(s_idirActiveKey);
             }
             finally
             {

--- a/visitz/VisitzApi/Vpi.cs
+++ b/visitz/VisitzApi/Vpi.cs
@@ -20,6 +20,7 @@ namespace VisitzApi
     /// </summary>
     public class Vpi(HttpClient httpClient, string baseVisitzApiUrl)
     {
+        internal static readonly string EmptyJsonBody = "{}";
         internal static readonly string V1 = "v1";
         internal static readonly string V2 = "v2";
 
@@ -43,6 +44,10 @@ namespace VisitzApi
 
             var response = await HttpClient.SendAsync(request);
             string content = await response.Content.ReadAsStringAsync();
+
+            if (content.Trim().Length <= 0)
+                content = EmptyJsonBody;
+
             using ResponseBodyParser bodyParser = new(content);
 
             endpoint.ThrowOnHttpErrors(response, bodyParser);


### PR DESCRIPTION
- Added semaphore when setting authorization status
- Use empty JSON obj when trying to parse an empty response body
- Cherry-pick auto-builds for .NET 9 builds from 3.0.0 branch